### PR TITLE
Added guarded-run to ease into fully automated merges

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -82,11 +82,11 @@ class ConfigOptions {
     mergedLabel() { return "M-merged"; }
     // merge started (tag and staging branch successfully adjusted)
     waitingStagingChecksLabel() { return "M-waiting-staging-checks"; }
-    // passed staging checks (in staged-run/guarded_run modes)
+    // passed staging checks (in staging-only mode)
     passedStagingChecksLabel() { return "M-passed-staging-checks"; }
     // future commit message violates requirements
     failedDescriptionLabel() { return "M-failed-description"; }
-    // allows final merge in 'guarded_run' mode
+    // allows target branch update in 'guarded_run' mode
     clearedForMergeLabel() { return "M-cleared-for-merge"; }
 }
 

--- a/Config.js
+++ b/Config.js
@@ -16,6 +16,7 @@ class ConfigOptions {
         this._stagingBranch = conf.staging_branch;
         this._dryRun = conf.dry_run;
         this._stagedRun = conf.staged_run;
+        this._guardedRun = conf.guarded_run;
         this._necessaryApprovals = conf.necessary_approvals;
         this._sufficientApprovals = conf.sufficient_approvals;
         assert(this._sufficientApprovals > 1);
@@ -65,6 +66,7 @@ class ConfigOptions {
     stagingBranchPath() { return "heads/" + this._stagingBranch; }
     dryRun() { return this._dryRun; }
     stagedRun() { return this._stagedRun; }
+    guardedRun() { return this._guardedRun; }
     necessaryApprovals() { return this._necessaryApprovals; }
     sufficientApprovals() { return this._sufficientApprovals; }
     votingDelayMax() { return this._votingDelayMax; }
@@ -80,10 +82,12 @@ class ConfigOptions {
     mergedLabel() { return "M-merged"; }
     // merge started (tag and staging branch successfully adjusted)
     waitingStagingChecksLabel() { return "M-waiting-staging-checks"; }
-    // passed staging checks (in staged-run mode)
+    // passed staging checks (in staged-run/guarded_run modes)
     passedStagingChecksLabel() { return "M-passed-staging-checks"; }
     // future commit message violates requirements
     failedDescriptionLabel() { return "M-failed-description"; }
+    // allows final merge in 'guarded_run' mode
+    clearedForMergeLabel() { return "M-cleared-for-merge"; }
 }
 
 const configFile = process.argv.length > 2 ? process.argv[2] : './config.json';

--- a/GitHubUtil.js
+++ b/GitHubUtil.js
@@ -225,6 +225,8 @@ function createReference(sha, ref) {
 
 function updateReference(ref, sha, force) {
     assert(!Config.dryRun());
+    assert((ref === Config.stagingBranchPath()) || !Config.stagedRun());
+
     let params = commonParams();
     params.ref = ref;
     params.sha = sha;

--- a/MergeContext.js
+++ b/MergeContext.js
@@ -234,8 +234,6 @@ class MergeContext {
     // throws on unexpected error
     async _finishMerging() {
         assert(this._tagSha);
-        assert(!Config.dryRun());
-        assert(!Config.stagedRun());
         this._log("finish merging...");
         try {
             await GH.updateReference(this._prBaseBranchPath(), this._tagSha, false);

--- a/MergeContext.js
+++ b/MergeContext.js
@@ -19,6 +19,10 @@ class MergeContext {
     // Returns 'true' if all PR checks passed successfully and merging
     // started,'false' if we can't start the PR due to some failed checks.
     async startProcessing() {
+        // TODO: Optimize old/busy repo by quitting unless _prOpen().
+
+        // TODO: Optimize label tests by caching all PR labels here.
+
         if (!this._dryRun("reset labels before precondition checking"))
             await this._unlabelPreconditionsChecking();
 
@@ -80,12 +84,7 @@ class MergeContext {
         if (this._dryRun("finish processing"))
             return false;
 
-        if (this._stagedRun("finish processing")) {
-            await this._labelPassedStagingChecks();
-            return false;
-        }
-
-        if (await this._guardedRun("finish processing")) {
+        if (this._stagingOnly("finish processing")) {
             await this._labelPassedStagingChecks();
             return false;
         }
@@ -235,6 +234,7 @@ class MergeContext {
     // throws on unexpected error
     async _finishMerging() {
         assert(this._tagSha);
+        assert(!Config.dryRun());
         assert(!Config.stagedRun());
         this._log("finish merging...");
         try {
@@ -562,6 +562,8 @@ class MergeContext {
         Log.Logger.info(this._debugString() + "):", msg);
     }
 
+    // TODO: Rename to _readOnly()
+    // whether all GitHub/repository changes are prohibited
     _dryRun(msg) {
         if (!Config.dryRun())
             return false;
@@ -569,22 +571,26 @@ class MergeContext {
         return true;
     }
 
-    _stagedRun(msg) {
-        if (!Config.stagedRun())
-            return false;
-        this._log("skip " + msg + " due to staged_run option");
-        return true;
-    }
+    // whether target branch changes are prohibited
+    async _stagingOnly(msg) {
+        // TODO: The caller should not have to remember to call _dryRun() first
+        assert(!this._dryRun("_stagingOnly"));
 
-    async _guardedRun(msg) {
-        if (!Config.guardedRun())
-            return false;
-        if (await this._hasLabel(Config.clearedForMergeLabel(), this._number())) {
-            this._log("allow " + msg + " due to guarded_run and " + Config.clearedForMergeLabel());
-            return false;
+        if (Config.stagedRun()) {
+            this._log("skip " + msg + " due to staged_run option");
+            return true;
         }
-        this._log("skip " + msg + " due to guarded_run option");
-        return true;
+
+        if (Config.guardedRun()) {
+            if (await this._hasLabel(Config.clearedForMergeLabel(), this._number())) {
+                this._log("allow " + msg + " due to " + Config.clearedForMergeLabel() + " overruling guarded_run option");
+                return false;
+            }
+            this._log("skip " + msg + " due to guarded_run option");
+            return true;
+        }
+
+        return false; // no staging-only mode by default
     }
 
     _toString() {

--- a/README.md
+++ b/README.md
@@ -156,12 +156,17 @@ request state:
   consult CI logs to determine what happened. The bot does not attempt
   to merge this PR again until the PR branch or PR target branch change.
   When the bot notices that change, it removes this label.
+* `M-cleared-for-merge`: A human allowed the bot running in
+  `config::staged_run` mode to merge the PR. The label has no effect
+  unless the bot is running in that mode. The bot never sets this label.
+  The bot removes this label after successfully merging the PR.
 * `M-merged`: The PR was successfully merged (and probably closed).
   The bot will not attempt to merge this PR again even if it is
   reopened. The bot never removes this label.
 
-All labels, except `M-merged`, are ignored by the bot itself! Humans
-may find them useful when determining the current state of a PR.
+All labels, except `M-cleared-for-merge` and `M-merged`, are ignored by
+the bot itself! Humans may find them useful when determining the current
+state of a PR.
 
 
 ## Commit message
@@ -271,7 +276,7 @@ All configuration fields are required.
 *repo* | The name of the GitHub repository that the bot should serve. | "squid"
 *owner* | The owner (a person or organization) of the GitHub repository. | "squid-cache"
 *dry_run*| A boolean option to enable read-only, no-modifications mode where the bot logs pull requests selected for merging but skips further merging steps, including PR labeling and commit tagging | false
-*staged_run*| A boolean option to enable no-final-modifications mode where the bot performs all the merging steps up to (and not including) the target branch update. Eligible PRs are merged into and tested on the staging branch but are never merged into their target branches. | false
+*staged_run*| A boolean option instructing the bot to avoid target branch updates unless the PR has a human-set `M-cleared-for-merge` label. When enabled, an eligible PR is merged into and tested on the staging branch. A successfully tested staged commit is then automatically merged into its target branch if and only if the PR has an `M-cleared-for-merge` label. | false
 *staging_branch* | The name of the bot-maintained git branch used for testing PR changes as if they were merged into their target branch. | auto
 *necessary_approvals* | The minimal number of core developers required for a PR to be merged. PRs with fewer votes are not merged, regardless of their age. | 1
 *sufficient_approvals* | The minimal number of core developers required for a PR to be merged fast (i.e., without waiting for `config::voting_delay_max`) | 2

--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ request state:
   `config::staging_checks` tests have completed.
 * `M-passed-staging-checks`: Similar to the GitHub "green check" mark
   for the staging branch commit (but ignores failures of optional
-  checks). Applied only if `config::staged_run` option is on. The bot
-  removes this label when either PR was successfully merged or staging
+  checks). Applied only when the bot is running in staging-only mode (see
+  `config::staged_run` and `config::guarded_run`). The bot removes this
+  label when either the PR was successfully merged or its staging
   results are no longer fresh/applicable.
 * `M-failed-staging-checks`: Essentially duplicates GitHub "red x" mark
   for the _staging commit_. The bot removes this label when it notices
@@ -156,10 +157,13 @@ request state:
   consult CI logs to determine what happened. The bot does not attempt
   to merge this PR again until the PR branch or PR target branch change.
   When the bot notices that change, it removes this label.
-* `M-cleared-for-merge`: A human allowed the bot running in
-  `config::staged_run` mode to merge the PR. The label has no effect
-  unless the bot is running in that mode. The bot never sets this label.
-  The bot removes this label after successfully merging the PR.
+* `M-cleared-for-merge`: A human has allowed the bot running in
+  `config::guarded_run` mode to perform the final merging step --
+  updating the target branch. The label has no effect unless the bot is
+  running in that mode. This is the only bot-related label that is meant
+  to be set by humans; the bot itself never sets this label. The bot
+  removes this label after successfully merging the PR. Avoid setting
+  this label unless you are a human responsible for testing the bot.
 * `M-merged`: The PR was successfully merged (and probably closed).
   The bot will not attempt to merge this PR again even if it is
   reopened. The bot never removes this label.
@@ -276,7 +280,8 @@ All configuration fields are required.
 *repo* | The name of the GitHub repository that the bot should serve. | "squid"
 *owner* | The owner (a person or organization) of the GitHub repository. | "squid-cache"
 *dry_run*| A boolean option to enable read-only, no-modifications mode where the bot logs pull requests selected for merging but skips further merging steps, including PR labeling and commit tagging | false
-*staged_run*| A boolean option instructing the bot to avoid target branch updates unless the PR has a human-set `M-cleared-for-merge` label. When enabled, an eligible PR is merged into and tested on the staging branch. A successfully tested staged commit is then automatically merged into its target branch if and only if the PR has an `M-cleared-for-merge` label. | false
+*staged_run*| A boolean option to enable staging-only mode where the bot performs all the merging steps up to (but not including) the target branch update. Eligible PRs are merged into and tested on the staging branch but are never merged into their target branches. Staging-only mode prevents any target branch modifications by the bot. TODO: Check that the PR target branch is not the configured staging branch, setting `M-failed-other` if needed. | false
+*guarded_run*| Enables staging-only mode (see `config::staged_run`) for PRs without a `M-cleared-for-merge` label. Has no effect on PRs with that label. While `config::staged_run` blocks target branch modifications, this option allows them for a human-designated subset of PRs. | false
 *staging_branch* | The name of the bot-maintained git branch used for testing PR changes as if they were merged into their target branch. | auto
 *necessary_approvals* | The minimal number of core developers required for a PR to be merged. PRs with fewer votes are not merged, regardless of their age. | 1
 *sufficient_approvals* | The minimal number of core developers required for a PR to be merged fast (i.e., without waiting for `config::voting_delay_max`) | 2
@@ -284,6 +289,8 @@ All configuration fields are required.
 *voting_delay_max* | The maximum merging age of a PR that has fewer than `config::sufficient_approvals` votes. The PR age string should comply with [timestring](https://github.com/mike182uk/timestring) parser. | "10d"
 *staging_checks*| The expected number of CI tests executed against the staging branch. | 2
 *logger_params* | A JSON-formatted parameter list for the [Bunyan](https://github.com/trentm/node-bunyan) logging library [constructor](https://github.com/trentm/node-bunyan#constructor-api). | <pre>{<br>    "name": "anubis",<br>    "streams": [ ... ]<br>}</pre>
+
+TODO: Merge all three "mutually exclusive" boolean `*_run` options into one `run_mode` option accepting on of four mode names, including "production". Document individual string values in a separate table (here).
 
 
 ## Caveats


### PR DESCRIPTION
We need a way to move from staged runs to automated commits without
risking massive wrong automated commits.