### PR TITLE
Moved bunyan 'stdout' configuration into config.json

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -4,7 +4,14 @@ const assert = require('assert');
 
 class ConfigOptions {
     constructor(fname) {
-        const conf = JSON.parse(fs.readFileSync(fname));
+        const conf = JSON.parse(fs.readFileSync(fname), (key, value) => {
+                    if (value === "process.stdout")
+                         return process.stdout;
+                    if (value === "process.stderr")
+                         return process.stderr;
+                    return value;
+                });
+
         this._githubUserLogin = conf.github_login;
         this._githubToken = conf.github_token;
         this._githubWebhookPath = conf.github_webhook_path;

--- a/Logger.js
+++ b/Logger.js
@@ -2,10 +2,7 @@ const assert = require('assert');
 const bunyan = require('bunyan');
 const Config = require('./Config.js');
 
-let Logger = null;
-
-Logger = bunyan.createLogger(Config.loggerParams());
-Logger.addStream({stream: process.stdout}); # XXX: Remove? We have Config.loggerParams().
+const Logger = bunyan.createLogger(Config.loggerParams());
 
 function LogError(err, context) {
     assert(context);

--- a/config-example.json
+++ b/config-example.json
@@ -23,6 +23,10 @@
             "path": "/var/log/anubis/debug.log",
             "period": "1d",
             "count": 3
+          },
+          {
+              "stream": "process.stdout",
+              "level": "info"
           }
         ]
     }


### PR DESCRIPTION
Added a workaround to support JSON-configurable stdout/stderr streams.

See also: https://github.com/trentm/node-bunyan/issues/153