### PR TITLE
Fixed (end of) line detection in PR descriptions

### DIFF
--- a/MergeContext.js
+++ b/MergeContext.js
@@ -513,7 +513,7 @@ class MergeContext {
     }
 
     _prMessageValid() {
-        const lines = this._prMessage().split('\n');
+        const lines = this._prMessage().split(/\r*\n/);
         for (let line of lines) {
             if (line.length > 72)
                 return false;


### PR DESCRIPTION
GitHub does not normalize line endings in PR descriptions. Its API may
yield CRLF or LF (at least) line endings in the descriptions, probably
depending on how the description was created or edited.