### PR TITLE
Missed 'await' for an async method

### DIFF
--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -84,7 +84,7 @@ class MergeContext {
         if (this._dryRun("finish processing"))
             return false;
 
-        if (this._stagingOnly("finish processing")) {
+        if (await this._stagingOnly("finish processing")) {
             await this._labelPassedStagingChecks();
             return false;
         }


### PR DESCRIPTION
Async MergeContext._stagingOnly() missed 'await' (caused by 906c63a).