### PR TITLE
Do not rely on object prototypes when evaluating 'code' error property

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -37,6 +37,7 @@ class ErrorContext extends Error {
     // be caused by a GitHub API error, so 'err' contains either
     // an error string or the entire API error object.
     constructor(err, method, args) {
+        assert(err);
         let msg = "";
         if (method !== undefined)
             msg = method + ", ";
@@ -51,10 +52,8 @@ class ErrorContext extends Error {
 
     // 404 (Not found)
     notFound() {
-        if (Object.getPrototypeOf(this._err) === Object.prototype) {
-            if ('code' in this._err)
-                return this._err.code === 404;
-        }
+        if (this._err.name === "HttpError")
+            return this._err.code === 404;
         // We treat our local(non-API) promise rejections as
         // if the requested resource was 'not found'.
         // TODO: rework if this simple approach does not work.
@@ -64,10 +63,8 @@ class ErrorContext extends Error {
     // 422 (unprocessable entity).
     // E.g., fast-forward failure returns this error.
     unprocessable() {
-        if (Object.getPrototypeOf(this._err) === Object.prototype) {
-            if ('code' in this._err)
-                return this._err.code === 422;
-        }
+        if (this._err.name === "HttpError")
+            return this._err.code === 422;
         return false;
     }
 }


### PR DESCRIPTION
Before this fix the ErrorContext class used the following approach: in
order to check whether _err.code field is meaningful, we checked for
the prototype first (so we could iterate over property list without
exceptions), and did this search then. However this approach is wrong
and gives incorrect results for different object prototypes (which can
be arbitrary specified with Object.setPrototypeOf() and can differ from
Object.prototype). Moreover, we do not even search through property
list, because the only assumed class with 'code' property in this
context is "HttpError".