### PR TITLE
Supply staged commits with required PR status checks

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -66,25 +66,6 @@ class ConfigOptions {
     githubToken() { return this._githubToken; }
     githubWebhookPath() { return this._githubWebhookPath; }
     githubWebhookSecret() { return this._githubWebhookSecret; }
-
-    githubPullRequestReviewEnforcementSettings() {
-        // {
-        //    "dismissal_restrictions": {
-        //      "users": [
-        //        "octocat"
-        //      ],
-        //      "teams": [
-        //        "justice-league"
-        //      ]
-        //    },
-        //    "dismiss_stale_reviews": true,
-        //    "require_code_owner_reviews": true,
-        //    "required_approving_review_count": 2
-        // }
-        return {
-            "required_approving_review_count": 1
-        };
-    }
     repo() { return this._repo; }
     host() { return this._host; }
     port() { return this._port; }

--- a/src/Config.js
+++ b/src/Config.js
@@ -66,6 +66,25 @@ class ConfigOptions {
     githubToken() { return this._githubToken; }
     githubWebhookPath() { return this._githubWebhookPath; }
     githubWebhookSecret() { return this._githubWebhookSecret; }
+
+    githubPullRequestReviewEnforcementSettings() {
+        // {
+        //    "dismissal_restrictions": {
+        //      "users": [
+        //        "octocat"
+        //      ],
+        //      "teams": [
+        //        "justice-league"
+        //      ]
+        //    },
+        //    "dismiss_stale_reviews": true,
+        //    "require_code_owner_reviews": true,
+        //    "required_approving_review_count": 2
+        // }
+        return {
+            "required_approving_review_count": 1
+        };
+    }
     repo() { return this._repo; }
     host() { return this._host; }
     port() { return this._port; }

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -474,6 +474,7 @@ function protectedBranchParams() {
     return params;
 }
 
+// unused
 function getProtectedBranchPullRequestReviewEnforcement(branch) {
     const params = protectedBranchParams();
     params.branch = branch;

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -379,6 +379,7 @@ function removeLabel(label, prNum) {
 //}
 
 function createStatus(sha, state, targetUrl, desc, context) {
+    assert(!Config.dryRun());
     let params = commonParams();
     params.sha = sha;
     params.state = state;

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -468,6 +468,64 @@ function getUserEmails() {
     });
 }
 
+function protectedBranchParams() {
+    const params = commonParams();
+    params.headers = { accept: 'application/vnd.github.luke-cage-preview+json' };
+    return params;
+}
+
+function getProtectedBranchPullRequestReviewEnforcement(branch) {
+    const params = protectedBranchParams();
+    params.branch = branch;
+    return new Promise( (resolve, reject) => {
+      GitHub.authenticate(GitHubAuthentication);
+      GitHub.repos.getProtectedBranchPullRequestReviewEnforcement(params, (err, res) => {
+          if (err) {
+             reject(new ErrorContext(err, getProtectedBranchPullRequestReviewEnforcement.name, params));
+             return;
+          }
+          logApiResult(getProtectedBranchPullRequestReviewEnforcement.name, params, res.data);
+          const result = res.data.required_approving_review_count !== undefined && res.data.required_approving_review_count > 0;
+          resolve(result);
+      });
+    });
+}
+
+function updateProtectedBranchPullRequestReviewEnforcement(branch) {
+    assert(!Config.dryRun());
+    const params = Object.assign(protectedBranchParams(), Config.githubPullRequestReviewEnforcementSettings());
+    params.branch = branch;
+    return new Promise( (resolve, reject) => {
+      GitHub.authenticate(GitHubAuthentication);
+      GitHub.repos.updateProtectedBranchPullRequestReviewEnforcement(params, (err, res) => {
+          if (err) {
+             reject(new ErrorContext(err, updateProtectedBranchPullRequestReviewEnforcement.name, params));
+             return;
+          }
+          logApiResult(updateProtectedBranchPullRequestReviewEnforcement.name, params, res.data);
+          resolve(res.data);
+      });
+    });
+}
+
+function removeProtectedBranchPullRequestReviewEnforcement(branch) {
+    assert(!Config.dryRun());
+    const params = protectedBranchParams();
+    params.branch = branch;
+    return new Promise( (resolve, reject) => {
+      GitHub.authenticate(GitHubAuthentication);
+      GitHub.repos.removeProtectedBranchPullRequestReviewEnforcement(params, (err, res) => {
+          if (err) {
+             reject(new ErrorContext(err, removeProtectedBranchPullRequestReviewEnforcement.name, params));
+             return;
+          }
+          const result = {deleted: true};
+          logApiResult(removeProtectedBranchPullRequestReviewEnforcement.name, params, res.data);
+          resolve(result);
+      });
+    });
+}
+
 module.exports = {
     getPRList: getPRList,
     getLabels: getLabels,
@@ -487,6 +545,9 @@ module.exports = {
     removeLabel: removeLabel,
     createStatus: createStatus,
     getProtectedBranchRequiredStatusChecks: getProtectedBranchRequiredStatusChecks,
+    getProtectedBranchPullRequestReviewEnforcement: getProtectedBranchPullRequestReviewEnforcement,
+    updateProtectedBranchPullRequestReviewEnforcement: updateProtectedBranchPullRequestReviewEnforcement,
+    removeProtectedBranchPullRequestReviewEnforcement: removeProtectedBranchPullRequestReviewEnforcement,
     getCollaborators: getCollaborators,
     getUser: getUser,
     getUserEmails: getUserEmails

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -468,65 +468,6 @@ function getUserEmails() {
     });
 }
 
-function protectedBranchParams() {
-    const params = commonParams();
-    params.headers = { accept: 'application/vnd.github.luke-cage-preview+json' };
-    return params;
-}
-
-// unused
-function getProtectedBranchPullRequestReviewEnforcement(branch) {
-    const params = protectedBranchParams();
-    params.branch = branch;
-    return new Promise( (resolve, reject) => {
-      GitHub.authenticate(GitHubAuthentication);
-      GitHub.repos.getProtectedBranchPullRequestReviewEnforcement(params, (err, res) => {
-          if (err) {
-             reject(new ErrorContext(err, getProtectedBranchPullRequestReviewEnforcement.name, params));
-             return;
-          }
-          logApiResult(getProtectedBranchPullRequestReviewEnforcement.name, params, res.data);
-          const result = res.data.required_approving_review_count !== undefined && res.data.required_approving_review_count > 0;
-          resolve(result);
-      });
-    });
-}
-
-function updateProtectedBranchPullRequestReviewEnforcement(branch) {
-    assert(!Config.dryRun());
-    const params = Object.assign(protectedBranchParams(), Config.githubPullRequestReviewEnforcementSettings());
-    params.branch = branch;
-    return new Promise( (resolve, reject) => {
-      GitHub.authenticate(GitHubAuthentication);
-      GitHub.repos.updateProtectedBranchPullRequestReviewEnforcement(params, (err, res) => {
-          if (err) {
-             reject(new ErrorContext(err, updateProtectedBranchPullRequestReviewEnforcement.name, params));
-             return;
-          }
-          logApiResult(updateProtectedBranchPullRequestReviewEnforcement.name, params, res.data);
-          resolve(res.data);
-      });
-    });
-}
-
-function removeProtectedBranchPullRequestReviewEnforcement(branch) {
-    assert(!Config.dryRun());
-    const params = protectedBranchParams();
-    params.branch = branch;
-    return new Promise( (resolve, reject) => {
-      GitHub.authenticate(GitHubAuthentication);
-      GitHub.repos.removeProtectedBranchPullRequestReviewEnforcement(params, (err, res) => {
-          if (err) {
-             reject(new ErrorContext(err, removeProtectedBranchPullRequestReviewEnforcement.name, params));
-             return;
-          }
-          const result = {deleted: true};
-          logApiResult(removeProtectedBranchPullRequestReviewEnforcement.name, params, res.data);
-          resolve(result);
-      });
-    });
-}
-
 module.exports = {
     getPRList: getPRList,
     getLabels: getLabels,
@@ -546,9 +487,6 @@ module.exports = {
     removeLabel: removeLabel,
     createStatus: createStatus,
     getProtectedBranchRequiredStatusChecks: getProtectedBranchRequiredStatusChecks,
-    getProtectedBranchPullRequestReviewEnforcement: getProtectedBranchPullRequestReviewEnforcement,
-    updateProtectedBranchPullRequestReviewEnforcement: updateProtectedBranchPullRequestReviewEnforcement,
-    removeProtectedBranchPullRequestReviewEnforcement: removeProtectedBranchPullRequestReviewEnforcement,
     getCollaborators: getCollaborators,
     getUser: getUser,
     getUserEmails: getUserEmails

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -378,6 +378,26 @@ function removeLabel(label, prNum) {
 //    });
 //}
 
+function createStatus(sha, state, targetUrl, desc, context) {
+    let params = commonParams();
+    params.sha = sha;
+    params.state = state;
+    params.target_url = targetUrl;
+    params.desc = desc;
+    params.context = context;
+    return new Promise( (resolve, reject) => {
+      GitHub.authenticate(GitHubAuthentication);
+      GitHub.repos.createStatus(params, (err, res) => {
+          if (err) {
+             reject(new ErrorContext(err, createCommit.name, params));
+             return;
+          }
+          const result = {context: res.data.context};
+          logApiResult(createStatus.name, params, result);
+          resolve(res.data.context);
+        });
+    });
+}
 
 function getProtectedBranchRequiredStatusChecks(branch) {
     let params = commonParams();
@@ -464,6 +484,7 @@ module.exports = {
     updatePR: updatePR,
     addLabels: addLabels,
     removeLabel: removeLabel,
+    createStatus: createStatus,
     getProtectedBranchRequiredStatusChecks: getProtectedBranchRequiredStatusChecks,
     getCollaborators: getCollaborators,
     getUser: getUser,

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -236,9 +236,12 @@ class MergeContext {
         assert(this._tagSha);
         this._log("finish merging...");
         try {
+            await GH.removeProtectedBranchPullRequestReviewEnforcement(this._prBaseBranch());
             await GH.updateReference(this._prBaseBranchPath(), this._tagSha, false);
+            await GH.updateProtectedBranchPullRequestReviewEnforcement(this._prBaseBranch());
             return true;
         } catch (e) {
+            await GH.updateProtectedBranchPullRequestReviewEnforcement(this._prBaseBranch());
             if (e.name === 'ErrorContext' && e.unprocessable()) {
                 this._log("fast-forwarding failed");
                 await this._cleanupMergeFailed(true);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -236,12 +236,9 @@ class MergeContext {
         assert(this._tagSha);
         this._log("finish merging...");
         try {
-            await GH.removeProtectedBranchPullRequestReviewEnforcement(this._prBaseBranch());
             await GH.updateReference(this._prBaseBranchPath(), this._tagSha, false);
-            await GH.updateProtectedBranchPullRequestReviewEnforcement(this._prBaseBranch());
             return true;
         } catch (e) {
-            await GH.updateProtectedBranchPullRequestReviewEnforcement(this._prBaseBranch());
             if (e.name === 'ErrorContext' && e.unprocessable()) {
                 this._log("fast-forwarding failed");
                 await this._cleanupMergeFailed(true);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -125,7 +125,7 @@ class MergeContext {
                 return true;
             }
         }
-        if (!Config.dryRun())
+        if (!this._dryRun("deleting staging commit"))
             await GH.deleteReference(this._stagingTag());
         return false;
     }
@@ -173,7 +173,7 @@ class MergeContext {
         // 'precondition' and 'postcondition' steps
         if (what === "precondition") {
             const messageValid = this._prMessageValid();
-            if (!Config.dryRun())
+            if (!this._dryRun("labeling on failed description"))
                 await this._labelFailedDescription(messageValid);
             if (!messageValid) {
                 this._log(what + " 'commit message' failed");
@@ -401,7 +401,8 @@ class MergeContext {
                     // from an already succeeded (matching) check (there can be several matching checks,
                     // e.g., from different Jenkins nodes). After that, there will be two checks
                     // referencing the same targetUrl.
-                    await GH.createStatus(ref, "success", matched.targetUrl, matched.description, requiredContext);
+                    if (!this._dryRun("required status check creation"))
+                        await GH.createStatus(ref, "success", matched.targetUrl, matched.description, requiredContext);
                 }
             }
         }


### PR DESCRIPTION
Add statuses of the required (and passed) PR checks to staged commit so
that GitHub allows the staged commit to be merged into a protected
target branch. Copying statuses is necessary when CI tests for a
staged commit differ from CI tests for PRs. When protecting a branch,
GitHub requires all commits going into that branch to pass the
required tests, and stage commit is no exception.

We only copy PR statuses when the staged commit passes staging tests.