### PR TITLE
Treat diverged branches specially when merging staged commit

### DIFF
--- a/src/Logger.js
+++ b/src/Logger.js
@@ -8,7 +8,7 @@ function LogError(err, context) {
     Log(err, context, "error");
 }
 
-function LogExceptionMessage(err, context) {
+function LogException(err, context) {
     Log(err, context, "info");
 }
 
@@ -31,7 +31,7 @@ function logApiResult(method, params, result) {
 module.exports = {
     Logger: Logger,
     LogError: LogError,
-    LogExceptionMessage: LogExceptionMessage,
+    LogException: LogException,
     logApiResult: logApiResult
 };
 

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -5,12 +5,23 @@ const Config = require('./Config.js');
 const Logger = bunyan.createLogger(Config.loggerParams());
 
 function LogError(err, context) {
+    Log(err, context, "error");
+}
+
+function LogExceptionMessage(err, context) {
+    Log(err, context, "info");
+}
+
+function Log(err, context, kind) {
     assert(context);
     let msg = (err.message === undefined) ? JSON.stringify(err) : err.message;
     msg = context + ": " + msg;
     if (err.stack !== undefined)
         msg += " " + err.stack.toString();
-    Logger.error(msg);
+    if (kind === "error")
+        Logger.error(msg);
+    else
+        Logger.info(msg);
 }
 
 function logApiResult(method, params, result) {
@@ -20,6 +31,7 @@ function logApiResult(method, params, result) {
 module.exports = {
     Logger: Logger,
     LogError: LogError,
+    LogExceptionMessage: LogExceptionMessage,
     logApiResult: logApiResult
 };
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -101,7 +101,7 @@ class MergeContext {
            this._tagSha = await GH.getReference(this._stagingTag());
        } catch (e) {
            if (e.name === 'ErrorContext' && e.notFound())
-               Log.LogExceptionMessage(e, this._toString() + " " + this._stagingTag() + " not found");
+               Log.LogException(e, this._toString() + " " + this._stagingTag() + " not found");
            else
                throw e;
        }
@@ -138,7 +138,8 @@ class MergeContext {
         return tagCommit.tree.sha === prCommit.tree.sha;
     }
 
-    // whether the tag commit and the base HEAD are 'diverged'
+    // whether the staged commit and the base HEAD have independent,
+    // (probably conflicting) changes
     async _tagDiverged() {
         try {
             const compareStatus = await GH.compareCommits(this._prBaseBranch(), this._stagingTag());
@@ -252,7 +253,7 @@ class MergeContext {
         } catch (e) {
             if (e.name === 'ErrorContext' && e.unprocessable()) {
                 if (await this._tagDiverged()) {
-                    Log.LogExceptionMessage(e, this._toString() + " fast-forwarding failed");
+                    Log.LogException(e, this._toString() + " fast-forwarding failed");
                     await this._cleanupMergeFailed(true);
                     return false;
                 }
@@ -364,7 +365,7 @@ class MergeContext {
             requiredContexts = await GH.getProtectedBranchRequiredStatusChecks(this._prBaseBranch());
         } catch (e) {
            if (e.name === 'ErrorContext' && e.notFound())
-               Log.LogExceptionMessage(e, this._toString() + " required status checks not found");
+               Log.LogException(e, this._toString() + " no status checks are required");
            else
                throw e;
         }
@@ -460,7 +461,7 @@ class MergeContext {
             await GH.removeLabel(label, this._number());
         } catch (e) {
             if (e.name === 'ErrorContext' && e.notFound()) {
-                Log.LogExceptionMessage(e, this._toString() + " removeLabel: " + label + " not found");
+                Log.LogException(e, this._toString() + " removeLabel: " + label + " not found");
                 return;
             }
             throw e;

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -101,7 +101,7 @@ class MergeContext {
            this._tagSha = await GH.getReference(this._stagingTag());
        } catch (e) {
            if (e.name === 'ErrorContext' && e.notFound())
-               this._log(this._stagingTag() + " not found");
+               Log.LogExceptionMessage(e, this._toString() + " " + this._stagingTag() + " not found");
            else
                throw e;
        }
@@ -136,6 +136,17 @@ class MergeContext {
         const prMergeSha = await GH.getReference(this._mergePath());
         const prCommit = await GH.getCommit(prMergeSha);
         return tagCommit.tree.sha === prCommit.tree.sha;
+    }
+
+    // whether the tag commit and the base HEAD are 'diverged'
+    async _tagDiverged() {
+        try {
+            const compareStatus = await GH.compareCommits(this._prBaseBranch(), this._stagingTag());
+            return compareStatus === "diverged";
+        } catch (e) {
+            Log.LogError(e, this._toString() + " compare commits failed");
+            return false;
+        }
     }
 
     // whether the being-in-merge PR state changed so that
@@ -240,9 +251,11 @@ class MergeContext {
             return true;
         } catch (e) {
             if (e.name === 'ErrorContext' && e.unprocessable()) {
-                this._log("fast-forwarding failed");
-                await this._cleanupMergeFailed(true);
-                return false;
+                if (await this._tagDiverged()) {
+                    Log.LogExceptionMessage(e, this._toString() + " fast-forwarding failed");
+                    await this._cleanupMergeFailed(true);
+                    return false;
+                }
             }
             throw e;
         }
@@ -351,7 +364,7 @@ class MergeContext {
             requiredContexts = await GH.getProtectedBranchRequiredStatusChecks(this._prBaseBranch());
         } catch (e) {
            if (e.name === 'ErrorContext' && e.notFound())
-               this._log("required status checks not found");
+               Log.LogExceptionMessage(e, this._toString() + " required status checks not found");
            else
                throw e;
         }
@@ -447,7 +460,7 @@ class MergeContext {
             await GH.removeLabel(label, this._number());
         } catch (e) {
             if (e.name === 'ErrorContext' && e.notFound()) {
-                this._log("removeLabel: " + label + " not found");
+                Log.LogExceptionMessage(e, this._toString() + " removeLabel: " + label + " not found");
                 return;
             }
             throw e;


### PR DESCRIPTION
When base fast-forwarding fails, a diverged target branch is the only
case where recreating the staged commit is a good idea. Other errors
(e.g., too strict protected branch settings or lack of permissions) are
not good reasons for re-staging: the bot should behave in this case
like in any other PR-specific failure case.

Also print full info for all caught exceptions, including when a
missing. These details could be useful for triage.