### PR TITLE
Do not duplicate exception messages

### DIFF
--- a/src/Logger.js
+++ b/src/Logger.js
@@ -14,10 +14,17 @@ function LogException(err, context) {
 
 function Log(err, context, kind) {
     assert(context);
-    let msg = (err.message === undefined) ? JSON.stringify(err) : err.message;
-    msg = context + ": " + msg;
-    if (err.stack !== undefined)
-        msg += " " + err.stack.toString();
+    msg = context + ": ";
+    // non-Error exceptions, like strings
+    if (err.message === undefined) {
+        msg += JSON.stringify(err);
+    }
+    else {
+        if (err.stack !== undefined)
+            msg += err.stack; // in Error, stack is prefixed with message
+        else
+            msg += err.message;
+    }
     if (kind === "error")
         Logger.error(msg);
     else

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -77,7 +77,7 @@ class PrMerger {
             return null;
         }
         const prNum = Util.ParseTag(tag.ref);
-        Logger.info("Current PR is " + prNum);
+        Logger.info("PR" + prNum + " is the current");
         const stagingPr = await GH.getPR(prNum, false);
         return new MergeContext(stagingPr, stagingSha);
     }


### PR DESCRIPTION
This duplication was caused by the fact that 'Error.stack'
is prefixed with Error.message, so printing Error.stack string
is enough.

Also unified one PR-mentioning log line: this unification
assumes logging such lines in PRXXX format(XXX - PR number).