### PR TITLE
Always refresh approval statuses and M-failed-description label

### DIFF
--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -62,14 +62,12 @@ class PrMerger {
     async _finishContext(context) {
         this.total = 1;
         const mergeFinish = await context.finishProcessing();
+        assert(!mergeFinish.delayed());
         if (mergeFinish.succeeded() || mergeFinish.failed())
             return true;
-
-        assert(mergeFinish.delayed() || mergeFinish.suspended());
-        if (mergeFinish.delayed()) {
-            if (this.rerunIn === null)
-                this.rerunIn = mergeFinish.delay();
-        }
+        // This result is when one of'dry run' bot options is on.
+        // Will wait while this option is on the way.
+        assert(mergeFinish.suspended());
         return false;
     }
 


### PR DESCRIPTION
... except cases when the PR is already closed or merged.  Before this
fix, checkMergeConditions() exited immediately when it stumbled upon a
failed condition. Obviously, before exiting, we need to sync independent
PR attributes (such as M-failed-description label or approval statuses),
since we request this information anyway.

Also: undone 0d00635 fix (the second 'also'). At finishProcessing()
stage, we cannot wait for a delay (which could appear, if the bot
time-voting settings have been changed), because these would
block other PRs. So, in such situation, we have to cleanup and let others
proceed.

Also: a couple of out-of-scope polishing fixes.