### PR TITLE
Process cleared for merge PRs first; fixed timeouts

### DIFF
--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -59,9 +59,11 @@ class PrMerger {
                 if (mergeStart.succeeded())
                     return true;
                 else if (mergeStart.delayed()) {
-                    // the first found will give us the minimal delay
                     if (this.rerunIn === null)
                         this.rerunIn = mergeStart.delay();
+                    else if (this.rerunIn > mergeStart.delay())
+                        this.rerunIn = mergeStart.delay();
+                    assert(this.rerunIn);
                 } else {
                     assert(mergeStart.failed() || mergeStart.suspended());
                 }


### PR DESCRIPTION
When possible, select the smallest PR cleared for merging instead of the
smallest PR that is otherwise ready for merge but has not been cleared
by a human yet. This is what users naturally want.

Side effect: Cleared PRs will have a priority in unguarded run mode.

XXX: guarded run mode: if there are no cleared PRs, we still start
working on an otherwise ready PR, often creating unwanted delays.
TODO: Abandon wrong guesses.

Also fixed rerun timeout calculation: This timeout should be calculated
as the minimum delay among delayed PRs.


