### PR TITLE
Improved and fixed status checks processing

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -105,6 +105,8 @@ class ConfigOptions {
 
     // the 'context name' of the approval test status
     approvalContext() { return "PR approval"; }
+
+    copiedDescriptionSuffix() { return " (copied from PR by Anubis)"; }
 }
 
 const configFile = process.argv.length > 2 ? process.argv[2] : './config.json';

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -120,12 +120,10 @@ class StatusCheck
         this.state = raw.state;
         this.targetUrl = raw.target_url;
         this.description = raw.description;
-
-        this._raw = raw;
     }
 }
 
-// aggregates (required) status check for a PR or commit
+// aggregates (required) status checks for a PR or commit
 class StatusChecks
 {
     // expectedStatusCount:
@@ -169,10 +167,8 @@ class StatusChecks
             combinedStatus += "failure";
         else if (this.succeeded())
             combinedStatus += "success";
-        else if (this.final()) {
-            // final() implies failed() or succeeded()
-            combinedStatus += "unexpected";
-        }
+        else if (this.final())
+            combinedStatus += "unexpected"; // final() implies failed() or succeeded()
         else
             combinedStatus += "to-be-determined";
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -311,16 +311,7 @@ class MergeContext {
         const tagCommit = await GH.getCommit(this._tagSha);
         const prMergeSha = await GH.getReference(this._mergePath());
         const prCommit = await GH.getCommit(prMergeSha);
-        if (tagCommit.tree.sha !== prCommit.tree.sha) {
-            this._log("tag freshness: no (sha mismatch)");
-            return false;
-        }
-        if (this._prMessage() !== tagCommit.message) {
-            this._log("tag freshness: no (message mismatch)");
-            return false;
-        }
-        this._log("tag freshness: yes");
-        return true;
+        return tagCommit.tree.sha === prCommit.tree.sha;
     }
 
     // whether the staged commit and the base HEAD have independent,

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -311,7 +311,16 @@ class MergeContext {
         const tagCommit = await GH.getCommit(this._tagSha);
         const prMergeSha = await GH.getReference(this._mergePath());
         const prCommit = await GH.getCommit(prMergeSha);
-        return tagCommit.tree.sha === prCommit.tree.sha;
+        if (tagCommit.tree.sha !== prCommit.tree.sha) {
+            this._log("tag freshness: no (sha mismatch)");
+            return false;
+        }
+        if (this._prMessage() !== tagCommit.message) {
+            this._log("tag freshness: no (message mismatch)");
+            return false;
+        }
+        this._log("tag freshness: yes");
+        return true;
     }
 
     // whether the staged commit and the base HEAD have independent,

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -518,8 +518,14 @@ class MergeContext {
         }
 
         const prAgeMs = new Date() - new Date(this._createdAt());
-        if (prAgeMs < Config.votingDelayMin())
+        if (prAgeMs < Config.votingDelayMin()) {
+            if (usersApproved.length < Config.sufficientApprovals()) {
+                this._log("not approved by sufficient " + Config.sufficientApprovals() +
+                        " votes within " + Config.votingDelayMin() + " ms");
+                return Approval.Suspend("waiting for more votes");
+            }
             return Approval.GrantAfterTimeout("waiting for fast track objections", Config.votingDelayMin() - prAgeMs);
+        }
 
         if (usersApproved.length >= Config.sufficientApprovals())
             return Approval.GrantNow("approved");


### PR DESCRIPTION
Added a new StatusResult class having all required methods for status
checks analysis. With it, fixed and clarified status checking algorithm.
Before this fix, the bot could ignore required checks after changing
GitHub configuration  (or after adding new staged checks). To make
statuses checking more clear, refactored, separating the code into
two cases:

1. PR-statuses (_checkPRStatuses()). The list of checks is verified
against GtiHub-required checks list.

2. Staging-statuses  (_processStagingStatuses()). All staging checks are
assumed 'required'. The bot needs at least 'staging_checks' number of
checks for the staging commit. When all staging checks succeed, one
more step is performed: applying GitHub-required checks to the staged
commit. This step is needed to overcome GitHub protection for staged
commits.

Also: fixed approval status calculation within fast track period. During
that period, if vote number is less than sufficient_approvals, the status
should be 'waiting for more votes or a slow burner timeout', instead of
'waiting for fast track objections'.

Also: copy missing PR statuses into staging commit (instead of coping
'matching' staging statuses). Disadvantage: we mark staging commits
with unrelated (i.e. related to PR branch only) checks. Advantage: this
will work when we have different checks for PR and staging.
