### PR TITLE
PR message freshness postcondition

### DIFF
--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -256,7 +256,7 @@ class MergeContext {
         return result;
     }
 
-    // Whether the PR message has not changed since the PR staged commit creation.
+    // Whether the commit message configuration remained intact since staging.
     async _messageIsFresh() {
         const tagCommit = await this._tagCommit();
         const result = this._prMessage() === tagCommit.message;

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -118,6 +118,8 @@ class MergeContext {
         this._shaLimit = 6;
         // information used for approval test status creation/updating
         this._approval = null;
+        // optimization: cached _tagCommit() result
+        this._tagCommitCache = null;
     }
 
     // returns filled StepResult object
@@ -235,12 +237,18 @@ class MergeContext {
         return false;
     }
 
+    async _tagCommit() {
+        if (this._tagCommitCache)
+            return this._tagCommitCache;
+         this._tagCommitCache = await GH.getCommit(this._tagSha);
+         return this._tagCommitCache;
+    }
     // Whether the PR merge commit has not changed since the PR staged commit creation.
     // Note that it does not track possible conflicts between PR base branch and the
     // PR branch (the PR merge commit is recreated only when there are no conflicts).
     // Conflicts are tracked separately, by checking _prMergeable() flag.
     async _tagIsFresh() {
-        const tagCommit = await GH.getCommit(this._tagSha);
+        const tagCommit = await this._tagCommit();
         const prMergeSha = await GH.getReference(this._mergePath());
         const prCommit = await GH.getCommit(prMergeSha);
         const result = tagCommit.tree.sha === prCommit.tree.sha;
@@ -250,7 +258,7 @@ class MergeContext {
 
     // Whether the PR message has not changed since the PR staged commit creation.
     async _messageIsFresh() {
-        const tagCommit = await GH.getCommit(this._tagSha);
+        const tagCommit = await this._tagCommit();
         const result = this._prMessage() === tagCommit.message;
         this._log("tag message freshness: " + result);
         return result;

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -238,10 +238,9 @@ class MergeContext {
     }
 
     async _tagCommit() {
-        if (this._tagCommitCache)
-            return this._tagCommitCache;
-         this._tagCommitCache = await GH.getCommit(this._tagSha);
-         return this._tagCommitCache;
+        if (!this._tagCommitCache)
+            this._tagCommitCache = await GH.getCommit(this._tagSha);
+        return this._tagCommitCache;
     }
     // Whether the PR merge commit has not changed since the PR staged commit creation.
     // Note that it does not track possible conflicts between PR base branch and the


### PR DESCRIPTION
With this additional postcondition, the bot tracks situations when PR
message was changed after tag creation. If so, the PR merging is started
from scratch, as usual.