### PR TITLE
guarded_run: M-cleared-for-merge PRs should not wait for others

### DIFF
--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -59,6 +59,8 @@ function getPRList() {
             res = await pager(res);
             const result = res.data.length;
             logApiResult(getPRList.name, params, result);
+            for (let pr of res.data)
+                pr.anubisProcessor = null;
             resolve(res.data);
         });
     });

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -355,7 +355,7 @@ class MergeContext {
         this._log("checking merge " + what + "s...");
         this._approval = null;
 
-        const pr = await GH.getPR(this._number(), true);
+        const pr = await GH.getPR(this.number(), true);
         // refresh PR data
         assert(pr.number === this._pr.number);
         this._pr = pr;
@@ -365,7 +365,7 @@ class MergeContext {
             return StepResult.Fail();
         }
 
-        if (await this._hasLabel(Config.mergedLabel(), this._number())) {
+        if (await this._hasLabel(Config.mergedLabel(), this.number())) {
             this._log(what + " 'already merged' failed");
             return StepResult.Fail();
         }
@@ -430,7 +430,7 @@ class MergeContext {
     async _startMerging() {
         this._log("start merging...");
         const baseSha = await GH.getReference(this._prBaseBranchPath());
-        const mergeSha = await GH.getReference("pull/" + this._number() + "/merge");
+        const mergeSha = await GH.getReference("pull/" + this.number() + "/merge");
         const mergeCommit = await GH.getCommit(mergeSha);
         if (!Config.githubUserName())
             await this._acquireUserProperties();
@@ -468,7 +468,7 @@ class MergeContext {
 
         this._log("merged, cleanup...");
         await this._labelMerged();
-        await GH.updatePR(this._number(), 'closed');
+        await GH.updatePR(this.number(), 'closed');
         await GH.deleteReference(this._stagingTag());
         return StepResult.Succeed();
     }
@@ -502,7 +502,7 @@ class MergeContext {
             }
         }
 
-        let reviews = await GH.getReviews(this._number());
+        let reviews = await GH.getReviews(this.number());
 
         // An array of [{reviewer, date, state}] elements,
         // where 'reviewer' is a core developer, 'date' the review date and 'state' is either
@@ -684,12 +684,12 @@ class MergeContext {
     // Label manipulation methods
 
     async _hasLabel(label) {
-        const labels = await GH.getLabels(this._number());
+        const labels = await GH.getLabels(this.number());
         return labels.find(lbl => lbl.name === label) !== undefined;
     }
 
     async _removeLabelsIf(labels) {
-        const currentLabels = await GH.getLabels(this._number());
+        const currentLabels = await GH.getLabels(this.number());
         for (let label of labels) {
             if (currentLabels.find(lbl => lbl.name === label) !== undefined)
                 await this._removeLabel(label);
@@ -700,7 +700,7 @@ class MergeContext {
 
     async _removeLabel(label) {
         try {
-            await GH.removeLabel(label, this._number());
+            await GH.removeLabel(label, this.number());
         } catch (e) {
             if (e.name === 'ErrorContext' && e.notFound()) {
                 Log.LogException(e, this._toString() + " removeLabel: " + label + " not found");
@@ -711,14 +711,14 @@ class MergeContext {
     }
 
     async _addLabel(label) {
-        const currentLabels = await GH.getLabels(this._number());
+        const currentLabels = await GH.getLabels(this.number());
         if (currentLabels.find(lbl => lbl.name === label) !== undefined) {
             this._log("addLabel: skip already existing " + label);
             return;
         }
 
         let params = Util.commonParams();
-        params.number = this._number();
+        params.number = this.number();
         params.labels = [];
         params.labels.push(label);
 
@@ -793,7 +793,7 @@ class MergeContext {
 
     // Getters
 
-    _number() { return this._pr.number; }
+    number() { return this._pr.number; }
 
     _prHeadSha() { return this._pr.head.sha; }
 
@@ -867,7 +867,7 @@ class MergeContext {
         }
 
         if (Config.guardedRun()) {
-            if (await this._hasLabel(Config.clearedForMergeLabel(), this._number())) {
+            if (await this._hasLabel(Config.clearedForMergeLabel(), this.number())) {
                 this._log("allow " + msg + " due to " + Config.clearedForMergeLabel() + " overruling guarded_run option");
                 return false;
             }

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -28,6 +28,7 @@ class PrMerger {
             pr.clearedForMerge = await this._clearedForMerge(pr.number);
 
         prList.sort((pr1, pr2) => { return pr2.clearedForMerge - pr1.clearedForMerge || pr1.number - pr2.number; });
+        this._logPRList(prList);
         return prList;
     }
 
@@ -43,12 +44,31 @@ class PrMerger {
     // there is a PR still-in-merge.
     async runStep() {
         Logger.info("runStep running");
-        const currentContext = await this._current();
-        if (currentContext && !(await this._finishContext(currentContext)))
-            return true; // still in-process
 
-        const prList = await this._getPRList();
-        this._logPRList(prList);
+        let prList = await this._getPRList();
+
+        let currentContext = await this._current();
+
+        if (currentContext && Config.guardedRun()) {
+            const clearedForMerge = await this._clearedForMerge(currentContext.number());
+            if (!clearedForMerge && prList.length && prList[0].clearedForMerge) {
+                Logger.info("will try to give up the not-cleared-for-merge PR" + currentContext.number() +
+                        " in favor of a cleared-for-merge PR" + prList[0].number);
+                // Give only other PRs a chance to start.
+                // Without removing current PR from the list, we can get into
+                // a loop of useless restarting it from scratch.
+                prList = prList.filter(pr => pr.number !== currentContext.number());
+                currentContext = null;
+            }
+        }
+
+        if (currentContext) {
+            if (!(await this._finishContext(currentContext)))
+                return true; // still in-process
+            // refresh the list
+            prList = await this._getPRList();
+            currentContext = null;
+        }
 
         while (prList.length) {
             try {
@@ -109,7 +129,11 @@ class PrMerger {
         }
         const prNum = Util.ParseTag(tag.ref);
         Logger.info("PR" + prNum + " is the current");
+        // TODO: handle 'not found' errors
         const stagingPr = await GH.getPR(prNum, false);
+        assert(stagingPr);
+        stagingPr.clearedForMerge = await this._clearedForMerge(prNum);
+
         return new MergeContext(stagingPr, stagingSha);
     }
 

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -28,7 +28,7 @@ class PrMerger {
         let prList = await GH.getPRList();
         for (let pr of prList) {
             pr.clearedForMerge = await this._clearedForMerge(pr.number);
-            if (finalizer !== null && finalizer._number() === pr.number) {
+            if (finalizer !== null && finalizer.number() === pr.number) {
                 pr.isCurrent = true;
                 pr.processor = finalizer;
             } else {


### PR DESCRIPTION
In guarded_run mode, PRs with the M-cleared-for-merge label have the
highest priority. The bot now gives up a being-processed unlabeled PR if
there is at least one labeled PR.