### PR TITLE
Properly handle PRs with empty descriptions

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -41,5 +41,10 @@ WebhookHandler.on('push', (ev) => {
     Merger.run();
 });
 
+WebhookHandler.on('ping', (ev) => {
+    const e = ev.payload;
+    Logger.info("ping event, hook_id:", e.hook_id);
+});
+
 Merger.run(WebhookHandler);
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -494,7 +494,7 @@ class MergeContext {
     _prHeadSha() { return this._pr.head.sha; }
 
     _prMessage() {
-        return this._pr.title + ' (#' + this._pr.number + ')' + '\n\n' + this._prBody();
+        return (this._pr.title + ' (#' + this._pr.number + ')' + '\n\n' + this._prBody()).trim();
     }
 
     _prMessageValid() {
@@ -527,7 +527,7 @@ class MergeContext {
 
     _prOpen() { return this._pr.state === 'open'; }
 
-    _prBody() { return this._pr.body.replace(/\r+\n/g, '\n'); }
+    _prBody() { return this._pr.body ? this._pr.body.replace(/\r+\n/g, '\n') : ""; }
 
     _stagingTag() { return Util.StagingTag(this._pr.number); }
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -527,7 +527,11 @@ class MergeContext {
 
     _prOpen() { return this._pr.state === 'open'; }
 
-    _prBody() { return this._pr.body ? this._pr.body.replace(/\r+\n/g, '\n') : ""; }
+    _prBody() {
+        if (this._pr.body === undefined || this._pr.body === null)
+            return "";
+        return this._pr.body.replace(/\r+\n/g, '\n');
+    }
 
     _stagingTag() { return Util.StagingTag(this._pr.number); }
 


### PR DESCRIPTION
Before this fix, the bot misinterpreted null message bodies.

Also:
* correctly compare commit messages with empty descriptions
* ping event logging (this event is sent during webhook creation)