### PR TITLE
Properly handle getReference() API call results

### DIFF
--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -219,6 +219,12 @@ function getReference(ref) {
                 reject(new ErrorContext(err, getReference.name, params));
                 return;
             }
+            // If the ref does not exist, but  but existing refs start with ref,
+            // an array is returned.
+            if (res.data === undefined || res.data.object === undefined) {
+                reject(new ErrorContext("Could not find " + params.ref + " reference", getReference.name, params));
+                return;
+            }
             const result = {ref: res.data.ref, sha: res.data.object.sha};
             logApiResult(getReference.name, params, result);
             resolve(res.data.object.sha);

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -219,9 +219,9 @@ function getReference(ref) {
                 reject(new ErrorContext(err, getReference.name, params));
                 return;
             }
-            // If the ref does not exist, but  but existing refs start with ref,
-            // an array is returned.
-            if (res.data === undefined || res.data.object === undefined) {
+            // If the requested ref does not exist in the repository, but some
+            // existing refs start with it, they will be returned as an array.
+            if (Array.isArray(res.data)) {
                 reject(new ErrorContext("Could not find " + params.ref + " reference", getReference.name, params));
                 return;
             }

--- a/src/Main.js
+++ b/src/Main.js
@@ -9,6 +9,7 @@ const WebhookHandler = createHandler({ path: Config.githubWebhookPath(), secret:
 
 process.on('unhandledRejection', error => {
     Logger.error("unhandledRejection", error.message);
+    process.exit(1);
 });
 
 // events

--- a/src/Main.js
+++ b/src/Main.js
@@ -7,6 +7,10 @@ const Logger = Log.Logger;
 
 const WebhookHandler = createHandler({ path: Config.githubWebhookPath(), secret: Config.githubWebhookSecret() });
 
+process.on('unhandledRejection', error => {
+    Logger.error("unhandledRejection", error.message);
+});
+
 // events
 
 WebhookHandler.on('error', (err) => {

--- a/src/Main.js
+++ b/src/Main.js
@@ -8,8 +8,8 @@ const Logger = Log.Logger;
 const WebhookHandler = createHandler({ path: Config.githubWebhookPath(), secret: Config.githubWebhookSecret() });
 
 process.on('unhandledRejection', error => {
-    Logger.error("unhandledRejection", error.message);
-    process.exit(1);
+    Logger.error("unhandledRejection", error.message, error.stack);
+    throw error;
 });
 
 // events


### PR DESCRIPTION
Before this fix, Anubis assumed that getReference() would return the
result only on exact ref matching. This is is not true: if the ref doesn't
exist in the repository, but there are other refs starting with the
ref, they are returned as an array. This resulted in an unhandled
exception within the promise and getting stuck on unresolved promise. We
should explicitly reject such mis-results.

Also I added a process unhandledRejection event handler to make it
easier to detect such bugs in the future.