### PR TITLE
Removed PR tags from the implementation

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -72,6 +72,7 @@ class ConfigOptions {
     port() { return this._port; }
     owner() { return this._owner; }
     stagingBranchPath() { return "heads/" + this._stagingBranch; }
+    stagingBranch() { return this._stagingBranch; }
     dryRun() { return this._dryRun; }
     stagedRun() { return this._stagedRun; }
     guardedRun() { return this._guardedRun; }

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -213,6 +213,25 @@ function compareCommits(baseRef, headRef) {
   });
 }
 
+function getCommits(branch, since) {
+    let params = commonParams();
+    params.sha = branch; // sha or branch to start listing commits from
+    params.since = since;
+    return new Promise( (resolve, reject) => {
+        GitHub.authenticate(GitHubAuthentication);
+        GitHub.repos.getCommits(params, async (err, res) => {
+            if (err) {
+                reject(new ErrorContext(err, getCommits.name, params));
+                return;
+            }
+            res = await pager(res);
+            const result = {commits: res.data.length};
+            logApiResult(getCommits.name, params, result);
+            resolve(res.data);
+        });
+  });
+}
+
 function getReference(ref) {
     let params = commonParams();
     params.ref = ref;
@@ -446,6 +465,7 @@ module.exports = {
     getReviews: getReviews,
     getStatuses: getStatuses,
     getCommit: getCommit,
+    getCommits: getCommits,
     createCommit: createCommit,
     compareCommits: compareCommits,
     getReference: getReference,

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -485,6 +485,24 @@ function getUserEmails() {
     });
 }
 
+function searchCommits(query) {
+    let params = {};
+    params.q = query;
+    params.sort = 'committer-date';
+    return new Promise( (resolve, reject) => {
+      GitHub.authenticate(GitHubAuthentication);
+      GitHub.search.commits(params, (err, res) => {
+          if (err) {
+             reject(new ErrorContext(err, searchCommits.name, params));
+             return;
+          }
+          const result = {count: res.data.total_count};
+          logApiResult(searchCommits.name, params, result);
+          resolve(res.data.items);
+      });
+    });
+}
+
 module.exports = {
     getOpenPrs: getOpenPrs,
     getLabels: getLabels,
@@ -506,6 +524,7 @@ module.exports = {
     getProtectedBranchRequiredStatusChecks: getProtectedBranchRequiredStatusChecks,
     getCollaborators: getCollaborators,
     getUser: getUser,
-    getUserEmails: getUserEmails
+    getUserEmails: getUserEmails,
+    searchCommits: searchCommits
 };
 

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -189,7 +189,7 @@ function createCommit(treeSha, message, parents, author, committer) {
             }
             const result = {sha: res.data.sha};
             logApiResult(createCommit.name, params, result);
-            resolve(res.data.sha);
+            resolve(res.data);
         });
   });
 }

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -213,7 +213,7 @@ function compareCommits(baseRef, headRef) {
   });
 }
 
-function getCommits(branch, since) {
+function getCommits(branch, since, author) {
     let params = commonParams();
     params.sha = branch; // sha or branch to start listing commits from
     params.since = since;

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -236,48 +236,6 @@ function getReference(ref) {
     });
 }
 
-// get all available repository tags
-function getTags() {
-    let params = commonParams();
-    return new Promise( (resolve, reject) => {
-        GitHub.authenticate(GitHubAuthentication);
-        GitHub.gitdata.getTags(params, async (err, res) => {
-            const notFound = (err && err.code === 404);
-            if (err && !notFound) {
-                reject(new ErrorContext(err, getTags.name, params));
-                return;
-            }
-            let result = [];
-            const gotSomeTags = !notFound;
-            if (gotSomeTags) {
-                res = await pager(res);
-                result = res.data;
-            }
-            logApiResult(getTags.name, params, {tags: result.length});
-            resolve(result);
-        });
-    });
-}
-
-function createReference(sha, ref) {
-    assert(!Config.dryRun());
-    let params = commonParams();
-    params.sha = sha;
-    params.ref = ref;
-    return new Promise( (resolve, reject) => {
-        GitHub.authenticate(GitHubAuthentication);
-        GitHub.gitdata.createReference(params, (err, res) => {
-            if (err) {
-                reject(new ErrorContext(err, createReference.name, params));
-                return;
-            }
-            const result = {ref: res.data.ref, sha: res.data.object.sha};
-            logApiResult(createReference.name, params, result);
-            resolve(res.data.object.sha);
-        });
-    });
-}
-
 function updateReference(ref, sha, force) {
     assert(!Config.dryRun());
     assert((ref === Config.stagingBranchPath()) || !Config.stagedRun());
@@ -296,28 +254,6 @@ function updateReference(ref, sha, force) {
             const result = {ref: res.data.ref, sha: res.data.object.sha};
             logApiResult(updateReference.name, params, result);
             resolve(res.data.object.sha);
-       });
-    });
-}
-
-// For the record: GitHub returns 422 error if there is no such
-// reference 'refs/:sha', and 404 if there is no such tag 'tags/:tag'.
-// Once I saw that both errors can be returned, so looks like this
-// GitHub behavior is unstable.
-function deleteReference(ref) {
-    assert(!Config.dryRun());
-    let params = commonParams();
-    params.ref = ref;
-    return new Promise( (resolve, reject) => {
-        GitHub.authenticate(GitHubAuthentication);
-        GitHub.gitdata.deleteReference(params, (err) => {
-            if (err) {
-                reject(new ErrorContext(err, deleteReference.name, params));
-                return;
-            }
-            const result = {deleted: true};
-            logApiResult(deleteReference.name, params, result);
-            resolve(result);
        });
     });
 }
@@ -513,10 +449,7 @@ module.exports = {
     createCommit: createCommit,
     compareCommits: compareCommits,
     getReference: getReference,
-    getTags: getTags,
-    createReference: createReference,
     updateReference: updateReference,
-    deleteReference: deleteReference,
     updatePR: updatePR,
     addLabels: addLabels,
     removeLabel: removeLabel,

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -672,7 +672,6 @@ class PullRequest {
         this._log("staged commit does not exist");
     }
 
-
     async _loadLabels() {
         let labels = await GH.getLabels(this._prNumber());
         assert(!this._labels);
@@ -897,8 +896,10 @@ class PullRequest {
         let commits = null;
 
         if (this._prBaseBranch() === 'master') {
-            const query = 'repo:' + Config.owner() + "/" + Config.repo() + '+#' + this._prNumber() +
-                '+author:' + this._prAuthor() + '+committer-date:>' + dateSince;
+            const query = 'repo:' + Config.owner() + "/" + Config.repo() +
+                '+ (#' + this._prNumber() + ')' +
+                '+author:' + this._prAuthor() +
+                '+committer-date:>' + dateSince;
             commits = await GH.searchCommits(query); // searches the default branch
         } else {
             commits = await GH.getCommits(this._prBaseBranch(), dateSince, this._prAuthor()); // searches any branch

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -448,7 +448,6 @@ class PullRequest {
         this._requiredContextsCache = null;
 
         this._stagedPosition = null;
-        this._freshStagedCommitWithFailedChecks = null;
 
         // this PR staged commit received from GitHub, if any
         this._stagedCommit = null;
@@ -952,7 +951,7 @@ class PullRequest {
         // Do not vainly recreate staged commit which will definitely fail again,
         // since the PR+base code is yet unchanged and the existing errors still persist
         if (stagedStatuses.failed()) {
-            this._freshStagedCommitWithFailedChecks = true;
+            this._labels.add(Config.failedStagingChecksLabel());
             await this._enterBrewing();
             return;
         }
@@ -1215,9 +1214,9 @@ class PullRequest {
          */
         await this._loadStaged();
         await this._loadRawPr(); // requires this._loadStaged()
-        await this._loadPrState(); // requires this._loadRawPr()
-        this._log("PR state: " + this._prState);
         await this._loadLabels();
+        await this._loadPrState(); // requires this._loadRawPr() and this._loadLabels()
+        this._log("PR state: " + this._prState);
 
         if (this._prState.brewing()) {
             await this._stage();

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1244,7 +1244,7 @@ class PullRequest {
 
             let result = new ProcessResult();
 
-            if (this._prState.staged()) {
+            if (this._prState && this._prState.staged()) {
                 if (suspended)
                     result.setPrStaged(true);
                 else
@@ -1259,6 +1259,8 @@ class PullRequest {
             // report this unknown but probably PR-specific problem on GitHub
             // XXX: We may keep redoing this PR every run() step forever, without any GitHub events.
             // TODO: Process Config.failedOtherLabel() PRs last and ignore their failures.
+            if (!this._labels)
+                this._labels = new Labels([], this._prNumber());
             this._labels.add(Config.failedOtherLabel());
             throw e;
         } finally {

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -98,15 +98,16 @@ class PrMerger {
         const stagedCommit = await GH.getCommit(stagedSha);
         const prNum = Util.ParsePrNumber(stagedCommit.message);
         if (prNum === null) {
-            Logger.info("No current PR found.");
-            return null;
+            Logger.info("Could not track a PR by the staged branch.");
+        } else {
+            const pr = await GH.getPR(prNum, false);
+            if (pr.state === 'open') {
+                Logger.info("PR" + prNum + " is the current");
+                return pr;
+            }
+            Logger.info("Tracked PR" + prNum + " by the staged branch but it is already closed.");
         }
-        const pr = await GH.getPR(prNum, false);
-        if (pr.state === 'open') {
-            Logger.info("PR" + prNum + " is the current");
-            return pr;
-        }
-        Logger.warn("The PR" + prNum + " is already closed.");
+        Logger.info("No current PR found.");
         return null;
     }
 } // PrMerger

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -96,8 +96,7 @@ class PrMerger {
         Logger.info("Looking for the current PR...");
         const stagedSha = await GH.getReference(Config.stagingBranchPath());
         const stagedCommit = await GH.getCommit(stagedSha);
-        Logger.info("Message: " + stagedCommit.message);
-        const prNum = Util.ParsePrMessage(stagedCommit.message);
+        const prNum = Util.ParsePrNumber(stagedCommit.message);
         if (prNum === null) {
             Logger.info("No current PR found.");
             return null;

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -94,9 +94,10 @@ class PrMerger {
     // If that PR exists, it is in either a "staged" or "merged" state.
     async _current() {
         Logger.info("Looking for the current PR...");
-        const stagedSha = await GH.getReference(Config.stagingBranchPath());
-        const stagedCommit = await GH.getCommit(stagedSha);
-        const prNum = Util.ParsePrNumber(stagedCommit.message);
+        const stagedBranchSha = await GH.getReference(Config.stagingBranchPath());
+        const stagedBranchCommit = await GH.getCommit(stagedBranchSha);
+        Logger.info("Staged branch head sha: " + stagedBranchCommit.sha);
+        const prNum = Util.ParsePrNumber(stagedBranchCommit.message);
         if (prNum === null) {
             Logger.info("Could not track a PR by the staged branch.");
         } else {

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -14,7 +14,6 @@ class PrMerger {
         this._total = 0; // the number of open PRs received from GitHub
         this._errors = 0; // the number of PRs with processing failures
         this._todo = null; // raw PRs to be processed
-        this._tags = null; // tags pointing to staged commits of _todo PRs
     }
 
     // Implements a single Anubis processing step.
@@ -25,8 +24,6 @@ class PrMerger {
         this._todo = await GH.getOpenPrs();
         this._total = this._todo.length;
         Logger.info(`Received ${this._total} PRs from GitHub:`, this._prNumbers());
-
-        await this._importTags(await GH.getTags()); // needs this._todo
 
         await this._determineProcessingOrder(await this._current());
 
@@ -93,51 +90,24 @@ class PrMerger {
         Logger.info("PR processing order:", this._prNumbers());
     }
 
-    // remembers still-relevant PR tags and
-    // deletes (from GitHub) PR tags which do not have a corresponding open PR
-    async _importTags(rawTags) {
-        assert(rawTags);
-
-        assert(!this._tags);
-        this._tags = [];
-
-        for (let tag of rawTags) {
-            let prNum = Util.ParseTag(tag.ref);
-            if (prNum === null)
-                continue;
-            for (let pr of this._todo) {
-                if (prNum === pr.number.toString()) {
-                    prNum = null;
-                    this._tags.push(tag);
-                    break;
-                }
-            }
-            if (prNum !== null) {
-                if (!Config.dryRun())
-                    await GH.deleteReference(Util.StagingTag(prNum));
-            }
-        }
-    }
-
     // Returns a raw PR with a staged commit (or null).
     // If that PR exists, it is in either a "staged" or "merged" state.
-    // Requires _importTags() being run first.
     async _current() {
         Logger.info("Looking for the current PR...");
-        const stagingSha = await GH.getReference(Config.stagingBranchPath());
-        // search for a tag, the staging_branch points to,
-        // and parse out PR number from the tag name
-        const tag = this._tags.find((t) => { return (t.object.sha === stagingSha) && Util.MatchTag(t.ref); });
-        if (tag === undefined) {
+        const stagedSha = await GH.getReference(Config.stagingBranchPath());
+        const stagedCommit = await GH.getCommit(stagedSha);
+        Logger.info("Message: " + stagedCommit.message);
+        const prNum = Util.ParsePrMessage(stagedCommit.message);
+        if (prNum === null) {
             Logger.info("No current PR found.");
             return null;
         }
-        const prNum = Util.ParseTag(tag.ref);
-        Logger.info("PR" + prNum + " is the current");
         const pr = await GH.getPR(prNum, false);
-        if (pr.state === 'open')
+        if (pr.state === 'open') {
+            Logger.info("PR" + prNum + " is the current");
             return pr;
-        Logger.warn("The current PR" + prNum + " unexpectedly closed.");
+        }
+        Logger.warn("The PR" + prNum + " is already closed.");
         return null;
     }
 } // PrMerger

--- a/src/Util.js
+++ b/src/Util.js
@@ -13,30 +13,15 @@ function commonParams() {
     };
 }
 
-const TagRegex = /(refs\/)(tags\/M-staged-PR)(\d+)$/;
-const PrNumberRegex = /(.* \(#)(\d+)(\))((\n\n)|($))/;
+const PrNumberRegex = /(.* \(#)(\d+)(\)$)/;
 
-function ParsePrMessage(message) {
-    const matched = message.match(PrNumberRegex);
+function ParsePrNumber(prMessage) {
+    assert(prMessage);
+    const lines = prMessage.split(/\r*\n/);
+    const matched = lines[0].match(PrNumberRegex);
     if (!matched)
         return null;
     return matched[2];
-}
-
-function MatchTag(ref) {
-    return ref.match(TagRegex) !== null;
-}
-
-function ParseTag(ref) {
-    const matched = ref.match(TagRegex);
-    if (!matched)
-        return null;
-    return matched[3];
-}
-
-function StagingTag(prNum) {
-    assert(prNum);
-    return "tags/M-staged-PR" + prNum;
 }
 
 // An error context for promisificated wrappers.
@@ -80,10 +65,7 @@ class ErrorContext extends Error {
 module.exports = {
     sleep: sleep,
     commonParams: commonParams,
-    StagingTag: StagingTag,
-    MatchTag: MatchTag,
-    ParseTag: ParseTag,
-    ParsePrMessage: ParsePrMessage,
+    ParsePrNumber: ParsePrNumber,
     ErrorContext: ErrorContext
 };
 

--- a/src/Util.js
+++ b/src/Util.js
@@ -13,7 +13,7 @@ function commonParams() {
     };
 }
 
-const PrNumberRegex = /(.* \(#)(\d+)(\)$)/;
+const PrNumberRegex = / \(#(\d+)\)$/;
 
 function ParsePrNumber(prMessage) {
     assert(prMessage);
@@ -21,7 +21,8 @@ function ParsePrNumber(prMessage) {
     const matched = lines[0].match(PrNumberRegex);
     if (!matched)
         return null;
-    return matched[2];
+    assert(matched[1] > 0);
+    return matched[1];
 }
 
 // An error context for promisificated wrappers.

--- a/src/Util.js
+++ b/src/Util.js
@@ -21,8 +21,9 @@ function ParsePrNumber(prMessage) {
     const matched = lines[0].match(PrNumberRegex);
     if (!matched)
         return null;
-    assert(matched[1] > 0);
-    return matched[1];
+    const prNumber = matched[1];
+    assert(prNumber > 0);
+    return prNumber;
 }
 
 // An error context for promisificated wrappers.

--- a/src/Util.js
+++ b/src/Util.js
@@ -14,6 +14,14 @@ function commonParams() {
 }
 
 const TagRegex = /(refs\/)(tags\/M-staged-PR)(\d+)$/;
+const PrNumberRegex = /(.* \(#)(\d+)(\))((\n\n)|($))/;
+
+function ParsePrMessage(message) {
+    const matched = message.match(PrNumberRegex);
+    if (!matched)
+        return null;
+    return matched[2];
+}
 
 function MatchTag(ref) {
     return ref.match(TagRegex) !== null;
@@ -75,6 +83,7 @@ module.exports = {
     StagingTag: StagingTag,
     MatchTag: MatchTag,
     ParseTag: ParseTag,
+    ParsePrMessage: ParsePrMessage,
     ErrorContext: ErrorContext
 };
 


### PR DESCRIPTION
We could not use PR tags anymore because new Git versions report errors
when encountering tag modifications.

Basically, PR tags helped with two problems:

* distinguish merged (but still open) PRs, in order to avoid processing
  this PR from scratch. Instead of this, we now track such PRs by
  searching the base branch commits for the ' (#NNN)' commit title
  suffix.

* mark failed staged commits and skip them (no modifications), thus
  avoiding the endless staged commit recreation. We now use
  M-failed-staged-checks label for this purpose: the bot ignores PRs
  marked with this label until a human clears it off; the bot itself
  does not clear it.