### PR TITLE
Prohibit non-ASCII_printable symbols in commit messages

### DIFF
--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -790,7 +790,7 @@ class PullRequest {
     // Searches for the first non_ASCII_printable character and returns
     // its position in the string.
     _invalidCharacterPosition(str) {
-        const prohibitedCharacters = /[^\x20-\x7e]/; // allow non-special ASCII characters
+        const prohibitedCharacters = /[^\u{20}-\u{7f}]/u; // allow non-special ASCII characters
         const match = prohibitedCharacters.exec(str);
         return match ? match.index : -1;
     }
@@ -799,7 +799,7 @@ class PullRequest {
         const lines = this._prMessage().split('\n');
         for (let i = 0; i < lines.length; ++i) {
             const line = lines[i];
-            // this._prBody() already cared about removing trailing \r characters
+            // this._prBody() already removed trailing \r characters
             const invalidPosition = this._invalidCharacterPosition(line);
             if (invalidPosition !== -1) {
                 this._warn(`PR message has an invalid character at line ${i}, offset ${invalidPosition}`);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -789,7 +789,7 @@ class PullRequest {
 
     // returns the position of the first non-ASCII_printable character (or -1)
     _invalidCharacterPosition(str) {
-        const prohibitedCharacters = /[^\u{20}-\u{7e}]/u; // allow non-special ASCII characters
+        const prohibitedCharacters = /[^\u{20}-\u{7e}]/u;
         const match = prohibitedCharacters.exec(str);
         return match ? match.index : -1;
     }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -787,6 +787,9 @@ class PullRequest {
         return (this._rawPr.title + ' (#' + this._rawPr.number + ')' + '\n\n' + this._prBody()).trim();
     }
 
+    // Searches for the first non_ASCII_printable character and returns
+    // its position in the string. By default, JavaScript strings are
+    // represented as a sequence of UTF-16 characters.
     _invalidCharacterPosition(str) {
         const prohibitedCharacters = /[^\u0020-\u007f]+/; // allow non-special ASCII characters
         const match = prohibitedCharacters.exec(str);
@@ -799,7 +802,7 @@ class PullRequest {
             const line = lines[i];
             const invalidPosition = this._invalidCharacterPosition(line);
             if (invalidPosition !== -1) {
-                this._warn("PR message has an invalid character at (" + i + "," + invalidPosition + ")");
+                this._warn(`PR message has an invalid character at line ${i}, offset ${invalidPosition}`);
                 return false;
             }
             if (line.length > 72)

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -788,10 +788,9 @@ class PullRequest {
     }
 
     // Searches for the first non_ASCII_printable character and returns
-    // its position in the string. By default, JavaScript strings are
-    // represented as a sequence of UTF-16 characters.
+    // its position in the string.
     _invalidCharacterPosition(str) {
-        const prohibitedCharacters = /[^\u0020-\u007f]+/; // allow non-special ASCII characters
+        const prohibitedCharacters = /[^\x20-\x7e]/; // allow non-special ASCII characters
         const match = prohibitedCharacters.exec(str);
         return match ? match.index : -1;
     }
@@ -800,6 +799,7 @@ class PullRequest {
         const lines = this._prMessage().split('\n');
         for (let i = 0; i < lines.length; ++i) {
             const line = lines[i];
+            // this._prBody() already cared about removing trailing \r characters
             const invalidPosition = this._invalidCharacterPosition(line);
             if (invalidPosition !== -1) {
                 this._warn(`PR message has an invalid character at line ${i}, offset ${invalidPosition}`);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -790,9 +790,7 @@ class PullRequest {
     _invalidCharacterPosition(str) {
         const prohibitedCharacters = /[^\u0020-\u007f]+/; // allow non-special ASCII characters
         const match = prohibitedCharacters.exec(str);
-        if (match)
-            return match.index;
-        return -1;
+        return match ? match.index : -1;
     }
 
     _prMessageValid() {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -789,7 +789,7 @@ class PullRequest {
 
     // returns the position of the first non-ASCII_printable character (or -1)
     _invalidCharacterPosition(str) {
-        const prohibitedCharacters = /[^\u{20}-\u{7f}]/u; // allow non-special ASCII characters
+        const prohibitedCharacters = /[^\u{20}-\u{7e}]/u; // allow non-special ASCII characters
         const match = prohibitedCharacters.exec(str);
         return match ? match.index : -1;
     }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -787,9 +787,23 @@ class PullRequest {
         return (this._rawPr.title + ' (#' + this._rawPr.number + ')' + '\n\n' + this._prBody()).trim();
     }
 
+    _invalidCharacterPosition(str) {
+        const prohibitedCharacters = /[^\u0020-\u007f]+/; // allow non-special ASCII characters
+        const match = prohibitedCharacters.exec(str);
+        if (match)
+            return match.index;
+        return -1;
+    }
+
     _prMessageValid() {
         const lines = this._prMessage().split('\n');
-        for (let line of lines) {
+        for (let i = 0; i < lines.length; ++i) {
+            const line = lines[i];
+            const invalidPosition = this._invalidCharacterPosition(line);
+            if (invalidPosition !== -1) {
+                this._warn("PR message has an invalid character at (" + i + "," + invalidPosition + ")");
+                return false;
+            }
             if (line.length > 72)
                 return false;
         }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -787,8 +787,7 @@ class PullRequest {
         return (this._rawPr.title + ' (#' + this._rawPr.number + ')' + '\n\n' + this._prBody()).trim();
     }
 
-    // Searches for the first non_ASCII_printable character and returns
-    // its position in the string.
+    // returns the position of the first non-ASCII_printable character (or -1)
     _invalidCharacterPosition(str) {
         const prohibitedCharacters = /[^\u{20}-\u{7f}]/u; // allow non-special ASCII characters
         const match = prohibitedCharacters.exec(str);
@@ -796,10 +795,11 @@ class PullRequest {
     }
 
     _prMessageValid() {
+        // _prBody() removed CRs in CRLF sequences
+        // other CRs are not treated specially (and are banned)
         const lines = this._prMessage().split('\n');
         for (let i = 0; i < lines.length; ++i) {
             const line = lines[i];
-            // this._prBody() already removed trailing \r characters
             const invalidPosition = this._invalidCharacterPosition(line);
             if (invalidPosition !== -1) {
                 this._warn(`PR message has an invalid character at line ${i}, offset ${invalidPosition}`);


### PR DESCRIPTION
isprint(3) defines "ASCII printable" symbol range as [0x20, 0x7E].