### PR TITLE
Ignore missing target_url in statuses

### DIFF
--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -133,7 +133,7 @@ class StatusCheck
 
         this.context = raw.context;
         this.state = raw.state;
-        this._targetUrl = raw.target_url;
+        this.targetUrl = raw.target_url;
         this.description = raw.description;
     }
 
@@ -142,15 +142,6 @@ class StatusCheck
     success() { return this.state === 'success'; }
 
     pending() { return this.state === 'pending'; }
-
-    targetUrl() {
-        // Ensure non-nil _targetUrl upon its usage.
-        // It may be still nil for some pending statuses.
-        // Callers are responsible for calling this method
-        // only for non-pending statuses.
-        assert(this._targetUrl);
-        return this._targetUrl;
-    }
 }
 
 // aggregates status checks for a PR or commit
@@ -1051,7 +1042,7 @@ class PullRequest {
 
             const check = new StatusCheck({
                     state: "success",
-                    target_url: requiredPrStatus.targetUrl(),
+                    target_url: requiredPrStatus.targetUrl,
                     description: requiredPrStatus.description + Config.copiedDescriptionSuffix(),
                     context: requiredPrStatus.context
                 });


### PR DESCRIPTION
Instead of marking the PR with M-failed-other, allow nil/empty
StatusCheck::targetUrl because GitHub does not require this field when
creating a new status for the staged commit, and Anubis does not use it
internally.

The target_url field is empty for the initial Jenkins 'pending' status,
when the test has been queued but not started yet.
