### PR TITLE
Added a new M-failed-staging-other label

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,17 @@ request state:
   (see below for PR commit message rules). The bot removes this label
   when it revisits the PR and notices that the commit message components
   were fixed.
-* `M-failed-other`: A fatal PR-specific error other than the staging
-  branch test failure (the latter is marked with
-  `M-failed-staging-checks`). It is probably necessary to
-  consult CI logs to determine what happened.
-  The bot removes this label once the problem is resolved.
+* `M-failed-staging-other`: A fatal PR-specific error occurred when waiting
+  for staging checks, other than the staging branch test failure (the
+  latter is marked with `M-failed-staging-checks`). It is probably
+  necessary to consult CI logs to determine what happened.  The bot does
+  not attempt to merge this PR again until a human decides that this
+  problem is resolved and removes the label manually.
+* `M-failed-other`: A fatal PR-specific error, not classified as
+  `M-failed-staging-other. It is probably necessary to consult CI
+  logs to determine what happened. When processing the PR again,
+  the bot automatically removes this label, optimistically assuming
+  that the problem may be solved by that time.
 * `M-cleared-for-merge`: A human has allowed the bot running in
   `config::guarded_run` mode to perform the final merging step --
   updating the target branch. The label has no effect unless the bot is

--- a/README.md
+++ b/README.md
@@ -144,16 +144,16 @@ request state:
   for the _staging commit_. The bot does not attempt to merge this PR
   again until a human decides that this problem is resolved and removes
   the label manually.
-* `M-failed-description`: The PR title and/or description is invalid
-  (see below for PR commit message rules). The bot removes this label
-  when it revisits the PR and notices that the commit message components
-  were fixed.
 * `M-failed-staging-other`: A fatal PR-specific error occurred when waiting
   for staging checks, other than the staging branch test failure (the
   latter is marked with `M-failed-staging-checks`). It is probably
   necessary to consult CI logs to determine what happened.  The bot does
   not attempt to merge this PR again until a human decides that this
   problem is resolved and removes the label manually.
+* `M-failed-description`: The PR title and/or description is invalid
+  (see below for PR commit message rules). The bot removes this label
+  when it revisits the PR and notices that the commit message components
+  were fixed.
 * `M-failed-other`: A fatal PR-specific error, not classified as
   `M-failed-staging-other`. It is probably necessary to consult CI
   logs to determine what happened. When processing the PR again,

--- a/README.md
+++ b/README.md
@@ -144,21 +144,20 @@ request state:
   for the _staging commit_. The bot does not attempt to merge this PR
   again until a human decides that this problem is resolved and removes
   the label manually.
-* `M-failed-staging-other`: A fatal PR-specific error occurred when waiting
-  for staging checks, other than the staging branch test failure (the
-  latter is marked with `M-failed-staging-checks`). It is probably
-  necessary to consult CI logs to determine what happened.  The bot does
-  not attempt to merge this PR again until a human decides that this
-  problem is resolved and removes the label manually.
+* `M-failed-staging-other`: A fatal PR-specific error that occurred while
+  waiting for staging checks but was not classified as
+  `M-failed-staging-checks`. It is probably necessary to consult CI logs to
+  determine what happened.  The bot does not attempt to merge this PR again
+  until a human decides that this problem is resolved and removes the label
+  manually.
 * `M-failed-description`: The PR title and/or description is invalid
   (see below for PR commit message rules). The bot removes this label
   when it revisits the PR and notices that the commit message components
   were fixed.
-* `M-failed-other`: A fatal PR-specific error, not classified as
-  `M-failed-staging-other`. It is probably necessary to consult CI
-  logs to determine what happened. When processing the PR again,
-  the bot automatically removes this label, optimistically assuming
-  that the problem may be solved by that time.
+* `M-failed-other`: All other fatal PR-specific errors. It is probably
+  necessary to consult CI logs to determine what happened. Anubis will process
+  the labeled PR again, optimistically assuming that the problems are
+  resolved. The bot removes the label if the problems are indeed gone.
 * `M-cleared-for-merge`: A human has allowed the bot running in
   `config::guarded_run` mode to perform the final merging step --
   updating the target branch. The label has no effect unless the bot is
@@ -170,9 +169,9 @@ request state:
   The bot will not attempt to merge this PR again even if it is
   reopened. The bot never removes this label.
 
-All labels, except `M-cleared-for-merge` and `M-merged`, are ignored by
-the bot itself! Humans may find them useful when determining the current
-state of a PR.
+All labels except `M-failed-staging-checks`, `M-failed-staging-other`,
+`M-cleared-for-merge`, and `M-merged` are ignored by Anubis! Humans may find
+them useful when determining the current state of a PR.
 
 
 ## Commit message

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ request state:
   not attempt to merge this PR again until a human decides that this
   problem is resolved and removes the label manually.
 * `M-failed-other`: A fatal PR-specific error, not classified as
-  `M-failed-staging-other. It is probably necessary to consult CI
+  `M-failed-staging-other`. It is probably necessary to consult CI
   logs to determine what happened. When processing the PR again,
   the bot automatically removes this label, optimistically assuming
   that the problem may be solved by that time.

--- a/src/Config.js
+++ b/src/Config.js
@@ -83,8 +83,10 @@ class ConfigOptions {
     stagingChecks() { return this._stagingChecks; }
     loggerParams() { return this._loggerParams; }
 
-    // fast-forward merge failed
+    // an unexpected error occurred (except from M-failed-staging-other).
     failedOtherLabel() { return "M-failed-other"; }
+    // an unexpected error occurred during 'staged' phase
+    failedStagingOtherLabel() { return "M-failed-staging-other"; }
     // some of required staging checks failed
     failedStagingChecksLabel() { return "M-failed-staging-checks"; }
     // fast-forward merge succeeded

--- a/src/Config.js
+++ b/src/Config.js
@@ -83,9 +83,9 @@ class ConfigOptions {
     stagingChecks() { return this._stagingChecks; }
     loggerParams() { return this._loggerParams; }
 
-    // an unexpected error occurred (except from M-failed-staging-other).
+    // an unexpected error occurred outside the "staged" phase
     failedOtherLabel() { return "M-failed-other"; }
-    // an unexpected error occurred during 'staged' phase
+    // an unexpected error occurred during the "staged" phase
     failedStagingOtherLabel() { return "M-failed-staging-other"; }
     // some of required staging checks failed
     failedStagingChecksLabel() { return "M-failed-staging-checks"; }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -777,7 +777,7 @@ class PullRequest {
         // Clear any positive labels (there should be no negatives here)
         // because Config.mergedLabel() set below already implies that all
         // intermediate processing steps have succeeded.
-        this._removeTemporaryLabelsSetByAnubis();
+        this._removeTemporaryLabels();
 
         this._labels.remove(Config.clearedForMergeLabel());
         this._labels.add(Config.mergedLabel());
@@ -1207,7 +1207,7 @@ class PullRequest {
         assert(this._prState.brewing());
 
         // methods below compute fresh labels from scratch
-        this._removeTemporaryLabelsSetByAnubis();
+        this._removeTemporaryLabels();
 
         await this._update();
         await this._checkStagingPreconditions();
@@ -1221,7 +1221,7 @@ class PullRequest {
         assert(this._prState.staged());
 
         // methods below compute fresh labels from scratch
-        this._removeTemporaryLabelsSetByAnubis();
+        this._removeTemporaryLabels();
 
         await this._update();
         await this._checkMergePreconditions();
@@ -1316,16 +1316,23 @@ class PullRequest {
         }
     }
 
-    // remove intermediate step labels that may be set by us
-    _removeTemporaryLabelsSetByAnubis() {
-        // Config.clearedForMergeLabel() is not temporary (only set by humans)
-        // Config.failedStagingChecksLabel() is not temporary (only cleared by humans)
-        // Config.failedStagingOtherLabel() is not temporary (only cleared by humans)
+    // Remove all labels that satisfy both criteria:
+    // * We set it. Some labels are only set by humans. A label X qualifies if
+    //   there is a labels.add(X) call somewhere.
+    // * We remove it. Some labels are only removed by humans. Some labels are
+    //   not meant to be removed at all! It is impossible to test this
+    //   criterion by searching Anubis code because some labels are only
+    //   removed by this method. Consult Anubis documentation instead.
+    // TODO: Add these properties to labels and iterate over all labels here.
+    _removeTemporaryLabels() {
+        // Config.clearedForMergeLabel() can only be set by a human
+        // Config.failedStagingChecksLabel() can only be removed by a human
+        // Config.failedStagingOtherLabel() can only be removed by a human
         this._labels.remove(Config.failedDescriptionLabel());
         this._labels.remove(Config.failedOtherLabel());
         this._labels.remove(Config.passedStagingChecksLabel());
         this._labels.remove(Config.waitingStagingChecksLabel());
-        // final (set after the PR is merged): Config.mergedLabel()
+        // Config.mergedLabel() is not meant to be removed by anybody
     }
 
     // remove labels that have no sense for a failed staged PR

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1257,9 +1257,9 @@ class PullRequest {
 
         await this._loadLabels();
 
-        // We obtained labels and can cleanup now.
-        // In a case of a new error, fresh values for error labels will be calculated.
-        this._labels.remove(Config.failedOtherLabel());
+        // methods below compute fresh labels from scratch without worrying
+        // about stale labels, so we clear all the labels that we must sync
+        this._removeTemporaryLabels();
 
         this._checkForHumanLabels();
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1235,13 +1235,14 @@ class PullRequest {
     async _doProcess() {
         this._breadcrumbs.push("load");
 
-        await this._loadLabels();
-        this.checkForHumanLabels();
-
         /*
          * Until _loadRawPr(), we must avoid this._rawPr fields except .number.
          * TODO: Refactor to eliminate the risk of too-early this._rawPr use.
          */
+
+        await this._loadLabels();
+        this.checkForHumanLabels();
+
         await this._loadStaged();
         await this._loadRawPr(); // requires this._loadStaged()
         await this._loadPrState(); // requires this._loadRawPr() and this._loadLabels()

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -710,7 +710,6 @@ class PullRequest {
         if (this._labels.has(Config.failedStagingChecksLabel()))
             throw this._exObviousFailure("staged commit tests failed");
 
-
         if (this._wipPr())
             throw this._exObviousFailure("work-in-progress");
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -679,8 +679,7 @@ class PullRequest {
         this._labels = new Labels(labels, this._prNumber());
     }
 
-    // check and throw if there are some human-controlled labels preventing the
-    // PR from further processing
+    // stop processing if it is prohibited by a human-controlled label
     _checkForHumanLabels() {
         if (this._labels.has(Config.failedStagingOtherLabel()))
             throw this._exObviousFailure("an unexpected error during staging some time ago");
@@ -704,7 +703,7 @@ class PullRequest {
 
         // TODO: If multiple failures need labeling, label all of them.
 
-        // must be already checked in _checkForHumanLabels()
+        // already checked in _checkForHumanLabels()
         assert(!this._labels.has(Config.failedStagingOtherLabel()));
 
         if (this._labels.has(Config.failedStagingChecksLabel()))

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -681,7 +681,7 @@ class PullRequest {
 
     // check and throw if there are some human-controlled labels preventing the
     // PR from further processing
-    checkForHumanLabels() {
+    _checkForHumanLabels() {
         if (this._labels.has(Config.failedStagingOtherLabel()))
             throw this._exObviousFailure("an unexpected error during staging some time ago");
     }
@@ -704,7 +704,7 @@ class PullRequest {
 
         // TODO: If multiple failures need labeling, label all of them.
 
-        // must be already checked in checkForHumanLabels()
+        // must be already checked in _checkForHumanLabels()
         assert(!this._labels.has(Config.failedStagingOtherLabel()));
 
         if (this._labels.has(Config.failedStagingChecksLabel()))
@@ -1241,7 +1241,7 @@ class PullRequest {
          */
 
         await this._loadLabels();
-        this.checkForHumanLabels();
+        this._checkForHumanLabels();
 
         await this._loadStaged();
         await this._loadRawPr(); // requires this._loadStaged()


### PR DESCRIPTION
This new label is set by the bot but cleared only by a human.  Its
purpose is to prevent PRs from 'livelocking' when an unexpected error
occurs during the staging phase. For example, if we have 2 PRs and one
of them experiences such an error, the control passes to the second PR
which (after creating a staged commit), gets into the same error,
passing the control back to the first PR and so on.