### PR TITLE
Added M-abandoned-staging-checks label

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ request state:
 * `M-merged`: The PR was successfully merged (and probably closed).
   The bot will not attempt to merge this PR again even if it is
   reopened. The bot never removes this label.
+* `M-abandoned-staging-checks`: The PR state changed, making the
+  still running CI tests stale/inapplicable. The bot removes this label
+  after creating a fresh stage commit for this PR.
 
 All labels, except `M-cleared-for-merge` and `M-merged`, are ignored by
 the bot itself! Humans may find them useful when determining the current

--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ request state:
   commits new code) or the staging_branch is unexpectedly modified. After
   labeling the PR, the bot ignores any failed or unfinished tests associated
   with that stale commit. This label was added so that the developer observing
-  the PR page on GitHub can be sure that Anubis had a good reason to ignore
-  failed or unfinished staging tests. The bot removes this (usually
-  short-lived) label after creating a fresh staging commit for the PR.
+  the PR page on GitHub knows why Anubis ignored (failed, unfinished, or
+  successful) staging tests. The bot removes this (usually short-lived) label
+  after creating a fresh staging commit for the PR.
 * `M-failed-staging-checks`: Essentially duplicates GitHub "red x" mark
   for the _staging commit_. The bot does not attempt to merge this PR
   again until a human decides that this problem is resolved and removes

--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ request state:
   mode (see `config::staged_run` and `config::guarded_run`). The bot
   removes this label when either the PR was successfully merged or its
   staging results are no longer fresh/applicable.
+* `M-abandoned-staging-checks`: Anubis discovered a stale _staging commit_.
+  This usually happens when either the PR state changes (e.g., the author
+  commits new code) or the staging_branch is unexpectedly modified. After
+  labeling the PR, the bot ignores any failed or unfinished tests associated
+  with that stale commit. This label was added so that the developer observing
+  the PR page on GitHub can be sure that Anubis had a good reason to ignore
+  failed or unfinished staging tests. The bot removes this (usually
+  short-lived) label after creating a fresh staging commit for the PR.
 * `M-failed-staging-checks`: Essentially duplicates GitHub "red x" mark
   for the _staging commit_. The bot does not attempt to merge this PR
   again until a human decides that this problem is resolved and removes
@@ -163,10 +171,6 @@ request state:
 * `M-merged`: The PR was successfully merged (and probably closed).
   The bot will not attempt to merge this PR again even if it is
   reopened. The bot never removes this label.
-* `M-abandoned-staging-checks`: The PR state changed, making the
-  still running (or already finished) CI tests stale/inapplicable.
-  The bot removes this label after creating a fresh stage commit for
-  this PR.
 
 All labels, except `M-cleared-for-merge` and `M-merged`, are ignored by
 the bot itself! Humans may find them useful when determining the current

--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ request state:
   The bot will not attempt to merge this PR again even if it is
   reopened. The bot never removes this label.
 * `M-abandoned-staging-checks`: The PR state changed, making the
-  still running CI tests stale/inapplicable. The bot removes this label
-  after creating a fresh stage commit for this PR.
+  still running (or already finished) CI tests stale/inapplicable.
+  The bot removes this label after creating a fresh stage commit for
+  this PR.
 
 All labels, except `M-cleared-for-merge` and `M-merged`, are ignored by
 the bot itself! Humans may find them useful when determining the current

--- a/src/Config.js
+++ b/src/Config.js
@@ -97,6 +97,8 @@ class ConfigOptions {
     failedDescriptionLabel() { return "M-failed-description"; }
     // allows target branch update in 'guarded_run' mode
     clearedForMergeLabel() { return "M-cleared-for-merge"; }
+    // whether the PR was abandoned due to a stale staged commit
+    abandonedStagingChecksLabel() { return "M-abandoned-staging-checks"; }
 
     // an URL of the description of the approval test status
     approvalUrl() { return this._approvalUrl; }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -299,6 +299,7 @@ class Labels
         return label;
     }
 
+    // adds a label and immediately applies it to GitHub
     async addAndPush(name) {
         const label = this.add(name);
         if (label.needsAdditionToGitHub()) {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -959,6 +959,7 @@ class PullRequest {
 
         if (!(await this._stagedCommitIsFresh())) {
             await this._enterBrewing();
+            this._labels.add(Config.abandonedStagingChecksLabel());
             return;
         }
 
@@ -1299,6 +1300,7 @@ class PullRequest {
         this._labels.remove(Config.failedOtherLabel());
         this._labels.remove(Config.passedStagingChecksLabel());
         this._labels.remove(Config.waitingStagingChecksLabel());
+        this._labels.remove(Config.abandonedStagingChecksLabel());
         // final (set after the PR is merged): Config.mergedLabel()
     }
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1309,7 +1309,6 @@ class PullRequest {
     _removeTemporaryLabelsSetByAnubis() {
         // set by humans: Config.clearedForMergeLabel();
         // set by humans: Config.failedStagingChecksLabel();
-        this._log("REMOVE temporary labels!!!");
         this._labels.remove(Config.failedDescriptionLabel());
         this._labels.remove(Config.failedOtherLabel());
         this._labels.remove(Config.passedStagingChecksLabel());

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -277,8 +277,9 @@ class Label
 }
 
 // Pull request labels. Hides the fact that some labels may be kept internally
-// while appearing to be unset for high-level code. Delays synchronization
-// with GitHub to help GitHub aggregate human-readable label change reports.
+// while appearing to be unset for high-level code. By default, delays
+// synchronization with GitHub to help GitHub aggregate human-readable label
+// change reports.
 class Labels
 {
     // the labels parameter is the label array received from GitHub
@@ -299,7 +300,7 @@ class Labels
         return label;
     }
 
-    // adds a label and immediately applies it to GitHub
+    // adds a label, updating GitHub without waiting for pushToGitHub()
     async addImmediately(name) {
         const label = this.add(name);
         if (label.needsAdditionToGitHub())

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -290,9 +290,9 @@ class Labels
     // adding a previously added or existing label is a no-op
     add(name) {
         let label = this._find(name);
-        if (label)
+        if (label) {
             label.markForAddition();
-        else {
+        } else {
             label = new Label(name, false);
             this._labels.push(label);
         }
@@ -302,9 +302,8 @@ class Labels
     // adds a label and immediately applies it to GitHub
     async addImmediately(name) {
         const label = this.add(name);
-        if (label.needsAdditionToGitHub()) {
+        if (label.needsAdditionToGitHub())
             await this._addToGitHub(label);
-        }
     }
 
     // removing a previously removed or missing label is a no-op

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -972,8 +972,8 @@ class PullRequest {
         }
 
         if (!(await this._stagedCommitIsFresh())) {
-            await this._enterBrewing();
             await this._labels.addAndPush(Config.abandonedStagingChecksLabel());
+            await this._enterBrewing();
             return;
         }
 


### PR DESCRIPTION
If a PR changes after staging, its staged commit is classified as
'stale' and abandoned. Then either a new staged commit is created or the
control passes to another PR. In both cases, it may be unclear (from a
user's point of view) why the bot abandoned this seemingly good
(i.e., possibly green) staged commit. The new label allows to
distinguish such situations.
