### PR TITLE
Force waiting for automated merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ All configuration fields are required.
 *voting_delay_max* | The maximum merging age of a PR that has fewer than `config::sufficient_approvals` votes. The PR age string should comply with [timestring](https://github.com/mike182uk/timestring) parser. | "10d"
 *staging_checks*| The expected number of CI tests executed against the staging branch. | 2
 *approval_url*| The URL associated with an approval status test description. | ""
+*automated_merge_url*| The URL associated with an automated merge status test description. | ""
 *logger_params* | A JSON-formatted parameter list for the [Bunyan](https://github.com/trentm/node-bunyan) logging library [constructor](https://github.com/trentm/node-bunyan#constructor-api). | <pre>{<br>    "name": "anubis",<br>    "streams": [ ... ]<br>}</pre>
 
 TODO: Merge all three "mutually exclusive" boolean `*_run` options into one `run_mode` option accepting on of four mode names, including "production". Document individual string values in a separate table (here).

--- a/src/Config.js
+++ b/src/Config.js
@@ -32,6 +32,7 @@ class ConfigOptions {
         this._stagingChecks = conf.staging_checks;
         this._loggerParams = conf.logger_params;
         this._approvalUrl = conf.approval_url;
+        this._automatedMergeUrl = conf.automated_merge_url;
 
         // unused
         this._githubUserNoreplyEmail = null;
@@ -112,6 +113,15 @@ class ConfigOptions {
     approvalContext() { return "PR approval"; }
 
     copiedDescriptionSuffix() { return " (copied from PR by Anubis)"; }
+
+    // an URL of the description of the automated merge test status
+    automatedMergeStatusUrl() { return this._automatedMergeUrl; }
+
+    // the 'context name' of the automated merge test status
+    automatedMergeStatusContext() { return "Merge automatically"; }
+
+    // whether the bot will create the automated merge test statuses for PR and staged commit
+    manageAutomatedMergeStatus() { return this.automatedMergeStatusUrl().length > 0; }
 }
 
 const configFile = process.argv.length > 2 ? process.argv[2] : './config.json';


### PR DESCRIPTION
Each GitHub PR has a manual merge button on the GitHub PR page,
which becomes green as soon as all preconditions (mandatory PR checks)
are satisfied. At that time, some admins may click on that button,
resulting in wrong commit messages and missing auto tests (at best).

To reduce the probability of such accidents, Anubis now automatically
adds a "waiting for automated merge" check, marked as required on
GitHub.

* For the staged commit, the check is satisfied immediately before
  the attempted merge (so that GitHub is happy about all the required
  status checks).

* For the PR, the check is satisfied only after Anubis merges the
  staged commit.