### PR TITLE
Abort stalled GitHub transactions

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -113,8 +113,9 @@ class ConfigOptions {
 
     copiedDescriptionSuffix() { return " (copied from PR by Anubis)"; }
 
-    // GitHub request timeout, ms
-    requestTimeout() { return 60000; }
+    // GitHub transaction timeout, ms
+    // GitHub library default is 0 which is interpreted as infinity (i.e. no timeout)
+    requestTimeout() { return 3 * 60000; }
 }
 
 const configFile = process.argv.length > 2 ? process.argv[2] : './config.json';

--- a/src/Config.js
+++ b/src/Config.js
@@ -112,6 +112,9 @@ class ConfigOptions {
     approvalContext() { return "PR approval"; }
 
     copiedDescriptionSuffix() { return " (copied from PR by Anubis)"; }
+
+    // GitHub request timeout, ms
+    requestTimeout() { return 60000; }
 }
 
 const configFile = process.argv.length > 2 ? process.argv[2] : './config.json';

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -1,9 +1,10 @@
 const assert = require('assert');
+const Config = require('./Config.js');
 const GitHub = require('@octokit/rest')({
+    timeout: Config.requestTimeout(),
     host: 'api.github.com',
     version: '3.0.0'
 });
-const Config = require('./Config.js');
 const Util = require('./Util.js');
 const Log = require('./Logger.js');
 


### PR DESCRIPTION
The bot may wait for a GitHub response for too long (several hours),
reacting to notifications but stalling progress on all PRs. We need a
timeout to avoid such delays. Fortunately, the octokit/rest library
provides the 'timeout' parameter (which defaults to no timeout). A
timed-out API call returns a 504 error, and we handle that correctly.

TODO: Eventually, we may add a more general "PR processing" timeout, but
this immediate solution is too simple to pass up.

Addresses issue #41.