### PR TITLE
Removed the need for humans to manage M-failed-staging-checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,11 @@ request state:
   after creating a fresh staging commit for the PR.
 * `M-failed-staging-checks`: Essentially duplicates GitHub "red x" mark
   for the _staging commit_. The bot does not attempt to merge this PR
-  again until a human decides that this problem is resolved and removes
-  the label manually.
+  again until either of two conditions:
+  * A human decides that this problem is resolved and removes the label
+  manually.
+  * This staging commit checks restart and succeed. In this case
+  Anubis proceeds with the PR, removing the label.
 * `M-failed-staging-other`: A fatal PR-specific error that occurred while
   waiting for staging checks but was not classified as
   `M-failed-staging-checks`. It is probably necessary to consult CI logs to

--- a/README.md
+++ b/README.md
@@ -150,11 +150,11 @@ request state:
   after creating a fresh staging commit for the PR.
 * `M-failed-staging-checks`: Essentially duplicates GitHub "red x" mark
   for the _staging commit_. The bot does not attempt to merge this PR
-  again until either of two conditions:
+  again until at least one of the following events happens:
   * A human decides that this problem is resolved and removes the label
-  manually.
-  * This staging commit checks restart and succeed. In this case
-  Anubis proceeds with the PR, removing the label.
+    manually.
+  * The failed checks for the staging commit are restarted or removed.
+  * The staging commit becomes stale. See `M-abandoned-staging-checks`.
 * `M-failed-staging-other`: A fatal PR-specific error that occurred while
   waiting for staging checks but was not classified as
   `M-failed-staging-checks`. It is probably necessary to consult CI logs to

--- a/README.md
+++ b/README.md
@@ -148,13 +148,10 @@ request state:
   the PR page on GitHub knows why Anubis ignored (failed, unfinished, or
   successful) staging tests. The bot removes this (usually short-lived) label
   after creating a fresh staging commit for the PR.
-* `M-failed-staging-checks`: Essentially duplicates GitHub "red x" mark
-  for the _staging commit_. The bot does not attempt to merge this PR
-  again until at least one of the following events happens:
-  * A human decides that this problem is resolved and removes the label
-    manually.
-  * The failed checks for the staging commit are restarted or removed.
-  * The staging commit becomes stale. See `M-abandoned-staging-checks`.
+* `M-failed-staging-checks`: Essentially duplicates GitHub "red x" mark for
+  the _staging commit_. The bot does not attempt to merge this PR until the
+  previously failed checks for the staging commit are abandoned (see
+  `M-abandoned-staging-checks`) or are restarted and finish successfully.
 * `M-failed-staging-other`: A fatal PR-specific error that occurred while
   waiting for staging checks but was not classified as
   `M-failed-staging-checks`. It is probably necessary to consult CI logs to

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1148,6 +1148,10 @@ class PullRequest {
         if (!this._prStatuses.final())
             throw this._exSuspend("waiting for PR branch tests that appeared after staging");
 
+        // All statuses are OK now, but they could be failed before (for the same staged commit).
+        // In this case, we should remove the (no longer actual) label.
+        this._labels.remove(Config.failedStagingChecksLabel());
+
         assert(this._prStatuses.succeeded());
 
         await this._processStagingStatuses();

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1051,9 +1051,6 @@ class PullRequest {
         if (this._stagedStatuses.failed())
             throw this._exLabeledFailure("staging tests failed", Config.failedStagingChecksLabel());
 
-        // remove a stale label, if any
-        this._labels.remove(Config.failedStagingChecksLabel());
-
         if (!this._stagedStatuses.final()) {
             this._labels.add(Config.waitingStagingChecksLabel());
             throw this._exSuspend("waiting for staging tests completion");
@@ -1339,21 +1336,22 @@ class PullRequest {
     }
 
     // Remove all labels that satisfy both criteria:
-    // * We set it. Some labels are only set by humans. A label X qualifies if
-    //   there is a labels.add(X) call somewhere.
-    // * We remove it. Some labels are only removed by humans. Some labels are
-    //   not meant to be removed at all! It is impossible to test this
+    // * We set it. This exclude labels that are only set by humans. A label X
+    //   qualifies if there is a labels.add(X) call somewhere.
+    // * We remove it. This includes labels that are also removed by humans.
+    //   This excludes labels that are only removed by humans and labels that
+    //   are not meant to be removed at all. It is impossible to test this
     //   criterion by searching Anubis code because some labels are only
     //   removed by this method. Consult Anubis documentation instead.
     // TODO: Add these properties to labels and iterate over all labels here.
     _removeTemporaryLabels() {
         // Config.clearedForMergeLabel() can only be set by a human
-        // Config.failedStagingChecksLabel() can only be removed by a human
         // Config.failedStagingOtherLabel() can only be removed by a human
         this._labels.remove(Config.failedDescriptionLabel());
         this._labels.remove(Config.failedOtherLabel());
         this._labels.remove(Config.passedStagingChecksLabel());
         this._labels.remove(Config.waitingStagingChecksLabel());
+        this._labels.remove(Config.failedStagingChecksLabel());
         this._labels.remove(Config.abandonedStagingChecksLabel());
         // Config.mergedLabel() is not meant to be removed by anybody
     }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1051,6 +1051,9 @@ class PullRequest {
         if (this._stagedStatuses.failed())
             throw this._exLabeledFailure("staging tests failed", Config.failedStagingChecksLabel());
 
+        // remove a stale label, if any
+        this._labels.remove(Config.failedStagingChecksLabel());
+
         if (!this._stagedStatuses.final()) {
             this._labels.add(Config.waitingStagingChecksLabel());
             throw this._exSuspend("waiting for staging tests completion");
@@ -1149,10 +1152,6 @@ class PullRequest {
             throw this._exSuspend("waiting for PR branch tests that appeared after staging");
 
         assert(this._prStatuses.succeeded());
-
-        // All statuses are OK now, but they could be failed before (for the same staged commit).
-        // In this case, we should remove the (no longer actual) label.
-        this._labels.remove(Config.failedStagingChecksLabel());
 
         await this._processStagingStatuses();
     }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1336,8 +1336,8 @@ class PullRequest {
     }
 
     // Remove all labels that satisfy both criteria:
-    // * We set it. This exclude labels that are only set by humans. A label X
-    //   qualifies if there is a labels.add(X) call somewhere.
+    // * We set it. This excludes labels that are only set by humans. A label
+    //   X qualifies if there is a labels.add(X) call somewhere.
     // * We remove it. This includes labels that are also removed by humans.
     //   This excludes labels that are only removed by humans and labels that
     //   are not meant to be removed at all. It is impossible to test this

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1148,11 +1148,11 @@ class PullRequest {
         if (!this._prStatuses.final())
             throw this._exSuspend("waiting for PR branch tests that appeared after staging");
 
+        assert(this._prStatuses.succeeded());
+
         // All statuses are OK now, but they could be failed before (for the same staged commit).
         // In this case, we should remove the (no longer actual) label.
         this._labels.remove(Config.failedStagingChecksLabel());
-
-        assert(this._prStatuses.succeeded());
 
         await this._processStagingStatuses();
     }


### PR DESCRIPTION
The bot relied on a human to delete some stale M-failed-staging-checks
labels but also ignored stale M-failed-staging-checks when the restarted
checks succeeded. The latter led to merged PRs still carrying a
M-failed-staging-checks label. While fixing that specific problem, we
realized that the bot can manage this label exclusively, without any
human help (and adjusted the code and documentation accordingly).

Also polished _removeTemporaryLabels() documentation even though the
now-explicitly-covered "labels that are also removed by humans" case
is currently not represented by any label.
