### PR TITLE
Removed GitHub master commits search optimization

### DIFF
--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -441,24 +441,6 @@ function getUserEmails() {
     });
 }
 
-function searchCommits(query) {
-    let params = {};
-    params.q = query;
-    params.sort = 'committer-date';
-    return new Promise( (resolve, reject) => {
-      GitHub.authenticate(GitHubAuthentication);
-      GitHub.search.commits(params, (err, res) => {
-          if (err) {
-             reject(new ErrorContext(err, searchCommits.name, params));
-             return;
-          }
-          const result = {count: res.data.total_count};
-          logApiResult(searchCommits.name, params, result);
-          resolve(res.data.items);
-      });
-    });
-}
-
 module.exports = {
     getOpenPrs: getOpenPrs,
     getLabels: getLabels,
@@ -478,7 +460,6 @@ module.exports = {
     getProtectedBranchRequiredStatusChecks: getProtectedBranchRequiredStatusChecks,
     getCollaborators: getCollaborators,
     getUser: getUser,
-    getUserEmails: getUserEmails,
-    searchCommits: searchCommits
+    getUserEmails: getUserEmails
 };
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -937,8 +937,8 @@ class PullRequest {
     /// Checks whether the PR base branch has this PR's staged commit merged.
     async _mergedSomeTimeAgo() {
         const dateSince = this._dateForDaysAgo(100);
-        let commits = await GH.getCommits(this._prBaseBranch(), dateSince, this._prAuthor());
         let mergedSha = null;
+        let commits = await GH.getCommits(this._prBaseBranch(), dateSince, this._prAuthor());
         for (let commit of commits) {
             const num = Util.ParsePrNumber(commit.commit.message);
             if (num && num === this._prNumber().toString()) {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -937,20 +937,7 @@ class PullRequest {
     /// Checks whether the PR base branch has this PR's staged commit merged.
     async _mergedSomeTimeAgo() {
         const dateSince = this._dateForDaysAgo(100);
-        let commits = null;
-
-        if (this._prBaseBranch() === this._defaultRepoBranch()) {
-            // Optimization: GitHub can search the default repository branch (which is usually master)
-            // by commit message substring
-            const query = 'repo:' + Config.owner() + "/" + Config.repo() +
-                '+ (#' + this._prNumber() + ')' +
-                '+author:' + this._prAuthor() +
-                '+committer-date:>' + dateSince;
-            commits = await GH.searchCommits(query); // searches the default branch
-        } else {
-            commits = await GH.getCommits(this._prBaseBranch(), dateSince, this._prAuthor()); // searches any branch
-        }
-
+        let commits = await GH.getCommits(this._prBaseBranch(), dateSince, this._prAuthor());
         let mergedSha = null;
         for (let commit of commits) {
             const num = Util.ParsePrNumber(commit.commit.message);


### PR DESCRIPTION
Github Search API has a custom rate limit, which is 30 requests per
minute for our token authorization. This limitation did not matter when
there were few open PRs. Now, as the PR list has grown, the limit was
reached on every pass (according to the bot logs) and several
unfortunate (random) PRs were constantly marked with M-failed-other.

Fortunately, we can do without this advanced Search API and use the
standard GitHub 'List commits' API. There is a couple of disadvantages
with this approach:

1. It does not allow filtering by searching for the PR number
in commit messages. As a result, if previously the received list of
commits was always empty (except rare cases when somebody has
merged PR by hand) but now it will usually contain several PRs and
the bot itself will filter the received results.

2. It is 15-20% slower, which may be a consequence of (1) due to the
increased data traffic. However, taking into account the 30/minute
limitation, the final PR scan time would be almost the same (with the
difference that Anubis would wait until GitHub resets its counters).


So, since the benefits of the advanced search are small versus
implementation complexity, we decided to drop it for good.