### PR TITLE
Recognize draft PRs as work-in-progress PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ are satisfied:
   text displayed by GitHub for these so called "mergeable" PRs varies
   depending on whether the changes are approved and whether the PR
   branch is out of date with its target branch.
+* The PR is not marked as being "in progress", which can be done either
+  with the "Draft pull request" GitHub setting (preferred) or prefixing
+  the PR title with "WIP:" (deprecated).
 * All the _required_ checks have succeeded on the PR branch:
   * If _all_ checks have succeeded, then GitHub says "All checks have
     passed" next to a green check mark:

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -727,6 +727,9 @@ class PullRequest {
         if (this._labels.has(Config.failedStagingChecksLabel()))
             throw this._exObviousFailure("staged commit tests failed");
 
+        if (this._draftPr())
+            throw this._exObviousFailure("draft PR");
+
         if (this._wipPr())
             throw this._exObviousFailure("work-in-progress");
 
@@ -841,6 +844,8 @@ class PullRequest {
     }
 
     _wipPr() { return this._rawPr.title.startsWith('WIP:'); }
+
+    _draftPr() { return this._rawPr.draft; }
 
     _prRequestedReviewers() {
         let reviewers = [];
@@ -1118,7 +1123,11 @@ class PullRequest {
         if (!this._messageValid)
             throw this._exLabeledFailure("commit message is now considered invalid", Config.failedDescriptionLabel());
 
-        assert(!this._wipPr());
+        if (this._draftPr())
+            throw this._exObviousFailure("restart due to draft PR");
+
+        if (this._wipPr())
+            throw this._exObviousFailure("restart due to work-in-progress");
 
         // TODO: unstage only if there is competition for being staged
 


### PR DESCRIPTION
PRs with the GitHub "Draft PR" setting are treated now as "WIP:" PRs.