### PR TITLE
Re-stage PRs after empty PR branch commits

### DIFF
--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -668,11 +668,15 @@ class PullRequest {
             const prMergeSha = await GH.getReference(this._mergePath());
             const prCommit = await GH.getCommit(prMergeSha);
             // whether the PR branch has not changed
-            const stagedCommitDate = new Date(this._stagedCommit.committer.date);
-            const prCommitDate = new Date(prCommit.committer.date);
-            if (stagedCommitDate > prCommitDate) {
-                this._log("the staged commit is fresh");
-                return true;
+            if (this._stagedCommit.tree.sha === prCommit.tree.sha) {
+                const stagedCommitDate = new Date(this._stagedCommit.committer.date);
+                const prCommitDate = new Date(prCommit.committer.date);
+                // check that a 'no-change' PR commit did not update the merge commit
+                // (which keeps the old tree object in this case)
+                if (stagedCommitDate >= prCommitDate) {
+                    this._log("the staged commit is fresh");
+                    return true;
+                }
             }
         }
         this._log("the staged commit is stale");

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -668,7 +668,9 @@ class PullRequest {
             const prMergeSha = await GH.getReference(this._mergePath());
             const prCommit = await GH.getCommit(prMergeSha);
             // whether the PR branch has not changed
-            if (this._stagedCommit.tree.sha === prCommit.tree.sha) {
+            const stagedCommitDate = new Date(this._stagedCommit.committer.date);
+            const prCommitDate = new Date(prCommit.committer.date);
+            if (stagedCommitDate > prCommitDate) {
                 this._log("the staged commit is fresh");
                 return true;
             }


### PR DESCRIPTION
After an empty PR branch commit, GitHub does not regenerate the tree
object of the PR merge commit. GitHub creates a new merge commit with
the old tree object instead. In this case, if the PR had a staged commit
already, the bot deemed it to be fresh because the staged commit and the
GitHub merge commit had the same commit tree (SHA). Users were naturally
surprised by the lack of a staged commit regeneration after a branch
change, especially since empty branch commits are usually used to
"awake" some automation, like CI stuck on an older (staged) commit.

This change was triggered by the following discussion:
https://github.com/squid-cache/squid/pull/651#issuecomment-639570539
