### PR TITLE
Do not uselessly flip M-abandoned-staging-checks

### DIFF
--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1305,6 +1305,9 @@ class PullRequest {
             else
                 this._logEx(e, "process() failure");
 
+            if (this._signalAbandonmentOfStagingChecks)
+                this._labels.add(Config.abandonedStagingChecksLabel());
+
             const suspended = knownProblem && e.keepStagedRequested(); // whether _exSuspend() occured
 
             let result = new ProcessResult();
@@ -1313,9 +1316,6 @@ class PullRequest {
                 result.setPrStaged(true);
             else
                 this._removePositiveStagingLabels();
-
-            if (this._signalAbandonmentOfStagingChecks)
-                this._labels.add(Config.abandonedStagingChecksLabel());
 
             if (knownProblem) {
                 result.setDelayMsIfAny(this._delayMs());


### PR DESCRIPTION
When this label was added in 5ef56f6, we wanted it to be short-lived,
set and cleared during a single PR processing cycle. It was
(immediately) set when Anubis found a stale staged commit. And it was
always (implicitly) cleared at the end of the cycle, probably under the
assumption that a fresh staged commit for the same PR would be created
during the same cycle, starting a new set of checks.

However, that assumption was sometimes wrong: Anubis may not stage a new
commit for the same PR (e.g., because a review was requested or another
PR has been staged). In those cases, Anubis will keep finding the same
stale staged commit, adding a label, and removing the label on every
GitHub event that leads to that PR processing, creating a lot of noise.

We now set (or keep) the label only if the new commit was not staged (or
merged).

Not setting (or clearing) the label if a new commit was staged (or
merged) solves the problem. However, it also means that the label will
not be set-and-removed if the stale staged commit was replaced with a
new one during the same processing cycle. This is an experiment: If the
absence of that short-lived label proves to be problematic, we will
restore its immediate setting (but will still keep it if the new commit
was not staged or merged).