### PR TITLE
Added the core_developers configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ below.
   confuse this general/imprecise term with the atomic action of merging
   one git branch into another.
 
-* _Core developer_: From the bot point of view, a core developer is a
-  GitHub user with write access to the configured repository (`config::repo`).
+* _Core developer_: A GitHub user listed in the config::core_developers
+  configuration parameter.
 
 
 ## Which pull requests are eligible for merging?
@@ -296,7 +296,7 @@ All configuration fields are required.
 *staging_branch* | The name of the bot-maintained git branch used for testing PR changes as if they were merged into their target branch. | auto
 *necessary_approvals* | The minimal number of core developers required for a PR to be merged. PRs with fewer votes are not merged, regardless of their age. | 1
 *sufficient_approvals* | The minimal number of core developers required for a PR to be merged fast (i.e., without waiting for `config::voting_delay_max`) | 2
-*core_developers* | The comma-separated list of login=id pairs representing GitHub core developers. | ""
+*core_developers* | The comma-separated list of login=id pairs, specifying GitHub login and ID for core developers. | ""
 *voting_delay_min*| The minimum merging age of a PR. Younger PRs are not merged, regardless of the number of votes. The PR age string should comply with [timestring](https://github.com/mike182uk/timestring) parser. | "2d"
 *voting_delay_max* | The maximum merging age of a PR that has fewer than `config::sufficient_approvals` votes. The PR age string should comply with [timestring](https://github.com/mike182uk/timestring) parser. | "10d"
 *staging_checks*| The expected number of CI tests executed against the staging branch. | 2

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ below.
   confuse this general/imprecise term with the atomic action of merging
   one git branch into another.
 
-* _Core developer_: A GitHub user listed in the config::core_developers
+* _Core developer_: A GitHub user listed in the `config::core_developers`
   configuration parameter.
 
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ All configuration fields are required.
 *staging_branch* | The name of the bot-maintained git branch used for testing PR changes as if they were merged into their target branch. | auto
 *necessary_approvals* | The minimal number of core developers required for a PR to be merged. PRs with fewer votes are not merged, regardless of their age. | 1
 *sufficient_approvals* | The minimal number of core developers required for a PR to be merged fast (i.e., without waiting for `config::voting_delay_max`) | 2
-*core_developers* | The comma-separated list of GitHub account IDs representing core developers (collaborators with push access rights) | ""
+*core_developers* | The comma-separated list of login=id pairs representing GitHub core developers. | ""
 *voting_delay_min*| The minimum merging age of a PR. Younger PRs are not merged, regardless of the number of votes. The PR age string should comply with [timestring](https://github.com/mike182uk/timestring) parser. | "2d"
 *voting_delay_max* | The maximum merging age of a PR that has fewer than `config::sufficient_approvals` votes. The PR age string should comply with [timestring](https://github.com/mike182uk/timestring) parser. | "10d"
 *staging_checks*| The expected number of CI tests executed against the staging branch. | 2

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ All configuration fields are required.
 *staging_branch* | The name of the bot-maintained git branch used for testing PR changes as if they were merged into their target branch. | auto
 *necessary_approvals* | The minimal number of core developers required for a PR to be merged. PRs with fewer votes are not merged, regardless of their age. | 1
 *sufficient_approvals* | The minimal number of core developers required for a PR to be merged fast (i.e., without waiting for `config::voting_delay_max`) | 2
+*core_developers* | The comma-separated list of GitHub account IDs representing core developers (collaborators with push access rights) | ""
 *voting_delay_min*| The minimum merging age of a PR. Younger PRs are not merged, regardless of the number of votes. The PR age string should comply with [timestring](https://github.com/mike182uk/timestring) parser. | "2d"
 *voting_delay_max* | The maximum merging age of a PR that has fewer than `config::sufficient_approvals` votes. The PR age string should comply with [timestring](https://github.com/mike182uk/timestring) parser. | "10d"
 *staging_checks*| The expected number of CI tests executed against the staging branch. | 2

--- a/src/Config.js
+++ b/src/Config.js
@@ -45,10 +45,15 @@ class ConfigOptions {
             assert(v !== undefined );
         }
 
-        this._coreDeveloperIds = this._coreDevelopers.split(',').map(i => Number(i.trim()));
-        const uniqDevelopers = [ ...new Set(this._coreDeveloperIds) ];
-        assert(uniqDevelopers.length === this._coreDeveloperIds.length);
-        assert(this._sufficientApprovals <= this._coreDeveloperIds.length);
+        let developerPairs = this._coreDevelopers.split(',').map(i => i.trim());
+        this._coreDeveloperIds = new Map();
+        for (let pair of developerPairs) {
+            let p = pair.split('=').map(i => i.trim());
+            assert(p.length === 2);
+            assert(!this._coreDeveloperIds.has(p[0]));
+            this._coreDeveloperIds.set(p[0], Number(p[1]));
+        }
+        assert(this._sufficientApprovals <= this._coreDeveloperIds.size);
     }
 
     githubUserLogin() { return this._githubUserLogin; }
@@ -88,6 +93,7 @@ class ConfigOptions {
     votingDelayMin() { return this._votingDelayMin; }
     stagingChecks() { return this._stagingChecks; }
     loggerParams() { return this._loggerParams; }
+    // returns a Map of (login,id) pairs
     coreDeveloperIds() { return this._coreDeveloperIds; }
 
     // an unexpected error occurred outside the "staged" phase

--- a/src/Config.js
+++ b/src/Config.js
@@ -45,15 +45,18 @@ class ConfigOptions {
             assert(v !== undefined );
         }
 
-        let developerPairs = this._coreDevelopers.split(',').map(i => i.trim());
         this._coreDeveloperIds = new Map();
+        const developerPairs = this._coreDevelopers.split(',').map(i => i.trim());
         for (let pair of developerPairs) {
-            let p = pair.split('=').map(i => i.trim());
+            assert(pair);
+            const p = pair.split('=').map(i => i.trim()).filter(i => i);
             assert(p.length === 2);
             assert(!this._coreDeveloperIds.has(p[0]));
             this._coreDeveloperIds.set(p[0], Number(p[1]));
         }
+        // check that it is actually possible to get all the configured votes
         assert(this._sufficientApprovals <= this._coreDeveloperIds.size);
+        assert(this._necessaryApprovals <= this._coreDeveloperIds.size);
     }
 
     githubUserLogin() { return this._githubUserLogin; }

--- a/src/Config.js
+++ b/src/Config.js
@@ -48,11 +48,13 @@ class ConfigOptions {
         this._coreDeveloperIds = new Map();
         const developerPairs = this._coreDevelopers.split(',').map(i => i.trim());
         for (let pair of developerPairs) {
-            assert(pair);
             const p = pair.split('=').map(i => i.trim()).filter(i => i);
             assert(p.length === 2);
             assert(!this._coreDeveloperIds.has(p[0]));
-            this._coreDeveloperIds.set(p[0], Number(p[1]));
+            const id = Number(p[1]);
+            assert(Number.isInteger(id));
+            assert(id > 0);
+            this._coreDeveloperIds.set(p[0], id);
         }
         // check that it is actually possible to get all the configured votes
         assert(this._sufficientApprovals <= this._coreDeveloperIds.size);

--- a/src/Config.js
+++ b/src/Config.js
@@ -32,6 +32,7 @@ class ConfigOptions {
         this._stagingChecks = conf.staging_checks;
         this._loggerParams = conf.logger_params;
         this._approvalUrl = conf.approval_url;
+        this._coreDevelopers = conf.core_developers;
 
         // unused
         this._githubUserNoreplyEmail = null;
@@ -43,6 +44,11 @@ class ConfigOptions {
         for (let v of allOptions) {
             assert(v !== undefined );
         }
+
+        this._coreDeveloperIds = this._coreDevelopers.split(',').map(i => Number(i.trim()));
+        const uniqDevelopers = [ ...new Set(this._coreDeveloperIds) ];
+        assert(uniqDevelopers.length === this._coreDeveloperIds.length);
+        assert(this._sufficientApprovals <= this._coreDeveloperIds.length);
     }
 
     githubUserLogin() { return this._githubUserLogin; }
@@ -82,6 +88,7 @@ class ConfigOptions {
     votingDelayMin() { return this._votingDelayMin; }
     stagingChecks() { return this._stagingChecks; }
     loggerParams() { return this._loggerParams; }
+    coreDeveloperIds() { return this._coreDeveloperIds; }
 
     // an unexpected error occurred outside the "staged" phase
     failedOtherLabel() { return "M-failed-other"; }

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -392,23 +392,6 @@ function getProtectedBranchRequiredStatusChecks(branch) {
     });
 }
 
-function getCollaborators() {
-    const params = commonParams();
-    return new Promise( (resolve, reject) => {
-      GitHub.authenticate(GitHubAuthentication);
-      GitHub.repos.getCollaborators(params, async (err, res) => {
-          if (err) {
-             reject(new ErrorContext(err, getCollaborators.name, params));
-             return;
-          }
-          res = await pager(res);
-          const result = {collaborators: res.data.length};
-          logApiResult(getCollaborators.name, params, result);
-          resolve(res.data);
-      });
-    });
-}
-
 function getUser(username) {
     const params = commonParams();
     params.username = username;
@@ -459,7 +442,6 @@ module.exports = {
     removeLabel: removeLabel,
     createStatus: createStatus,
     getProtectedBranchRequiredStatusChecks: getProtectedBranchRequiredStatusChecks,
-    getCollaborators: getCollaborators,
     getUser: getUser,
     getUserEmails: getUserEmails
 };

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -503,6 +503,7 @@ class PullRequest {
         if (!coreId)
             return false;
         this._log(`found core ${role}: ${userLogin}={userId}`);
+        this._log(`${role} is a core developer: ${userLogin}=${userId}`);
         // die if we are misconfigured and/or the userLogin has moved to another user
         assert.strictEqual(coreId, userId);
         return true;


### PR DESCRIPTION
Recently we started to experience persistent problems with
getCollaborators() GitHub API call, which incorrectly returned
less users than there really were. Now we specify core
collaborators manually, via a configuration option.