### PR TITLE
Convert Authored-By statement into commit author

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ PR merge, the target branch commit) from the following parts:
 * `author`: The name and email from the author object of the PR merge commit
   unless overwritten by the `Authored-by` header field value from the PR
   description header.
+* `date`: The date from the author object of the PR merge commit.
 
 Note that the individual commits on the PR branch (including their messages
 and authors) are ignored. The bot is effectively performing a squash merge

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ GitHub markdown to plain text. However, both texts must conform to the
 further reduces the maximum PR title length to ~65 characters. PRs violating
 these limits are labeled `M-failed-description` and are not merged.
 
+
 ## Voting and PR approvals
 
 The following events disqualify a pull request from automatic merging. A

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ PR merge, the target branch commit) from the following parts:
 * `author`: The name and email from the author object of the PR merge commit
   unless overwritten by the `Authored-by` header field value from the PR
   description header.
-* `date`: The date from the author object of the PR merge commit.
+* `author.date`: The date from the author object of the PR merge commit.
 
 Note that the individual commits on the PR branch (including their messages
 and authors) are ignored. The bot is effectively performing a squash merge

--- a/README.md
+++ b/README.md
@@ -196,35 +196,45 @@ GitHub markdown to plain text. However, both texts must conform to the
 further reduces the maximum PR title length to ~65 characters. PRs violating
 these limits are labeled `M-failed-description` and are not merged.
 
+
 ### Message attributes
 
-Commit message may contain special attributes, which are recognized and
+Commit description may contain special attributes, which are recognized and
 processed by the bot. If the bot cannot parse an attribute, it marks the PR
-it `M-failed-description` label.
+with `M-failed-description` label.
 
 1.`*Authored-by*` - The commit message author.
 We need to provide this attribute when the actual PR author is different from
 the author automatically provided by GitHub (which is the author of the PR branch
-first commit). The attribute should be specified at the beginning of the PR message.
-In order to avoid typos, lines starting with /\s*\S*Authored-By/ (except
-the first line and message trailers) are considered as invalid.
+first commit). The attribute should be specified at the beginning of the PR
+description and separated by an empty line from the rest of the message.  In order
+to avoid typos, the main part of the description (that is all lines excluding the
+first line and the message trailer) is subjected to a typo check, whereby lines
+starting with /\s*\S*Authored-By/ are considered as invalid.
 After the attribute value is parsed, the entire line (including empty lines
 below it) is removed from the message.
 The attribute is parsed according to the following ABNF rules:
-pr-author-paragraph = "Authored-By:" <SP> credentials eol empty-line+
-credentials = name+ "<" login "@" host ">"
-empty-line = eol
-eol = <CR>*<LF>
+```
+    pr-author-paragraph = "Authored-By:" <SP> credentials eol empty-line+
+    credentials = name+ "<" login "@" host ">"
+    empty-line = eol
+    eol = <CR>*<LF>
+```
 
 2. *Co-Authored-by* - The commit message co-author.
-These GitHub-recognized attribute allows to create a commit with multiple
-authors. If a message has an empty line followed by 'Co-authored-by: ',
-the bot treats this line and lines below as message trailer. Trailer
-section may contain multiple 'Co-authored-by' attrubutes, but other
-lines starting with /\s*\S*Authored-By/ are regarded as errors.
+This GitHub-recognized attribute allows to create a commit with multiple
+authors. It will be parsed by Anubis if it is specified within the last
+paragraph of the description (a.k.a. the trailer). Note that the bot recognizes
+the last paragraph as a trailer if and only if it contains attribute fields
+(i.e., `name: value` lines) and nothing else - otherwise this text block is
+considered belonging to the main part of the description and subjected to
+the typo check outlined above.
 The attribute is parsed according to the following ABNF rules:
-co-authors-paragraph = eol empty-line co-author-line+ empty-line\*
-co-author-line = "Co-Authored-By:" <SP> credentials eol
+```
+    co-authors-paragraph = eol empty-line co-author-line+ empty-line\*
+    co-author-line = "Co-Authored-By:" <SP> credentials eol
+```
+
 
 ## Voting and PR approvals
 

--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ request state:
   determine what happened.  The bot does not attempt to merge this PR again
   until a human decides that this problem is resolved and removes the label
   manually.
-* `M-failed-description`: The PR title and/or description is invalid
-  (see below for PR commit message rules). The bot removes this label
-  when it revisits the PR and notices that the commit message components
-  were fixed.
+* `M-failed-description`: The PR title and/or description is invalid (see
+  below for PR description and commit message rules). The bot removes this
+  label when it revisits the PR and notices that the future commit message
+  components were fixed.
 * `M-failed-other`: All other fatal PR-specific errors. It is probably
   necessary to consult CI logs to determine what happened. Anubis will process
   the labeled PR again, optimistically assuming that the problems are

--- a/README.md
+++ b/README.md
@@ -196,6 +196,35 @@ GitHub markdown to plain text. However, both texts must conform to the
 further reduces the maximum PR title length to ~65 characters. PRs violating
 these limits are labeled `M-failed-description` and are not merged.
 
+### Message attributes
+
+Commit message may contain special attributes, which are recognized and
+processed by the bot. If the bot cannot parse an attribute, it marks the PR
+it `M-failed-description` label.
+
+1.`*Authored-by*` - The commit message author.
+We need to provide this attribute when the actual PR author is different from
+the author automatically provided by GitHub (which is the author of the PR branch
+first commit). The attribute should be specified at the beginning of the PR message.
+In order to avoid typos, lines starting with /\s*\S*Authored-By/ (except
+the first line and message trailers) are considered as invalid.
+After the attribute value is parsed, the entire line (including empty lines
+below it) is removed from the message.
+The attribute is parsed according to the following ABNF rules:
+pr-author-paragraph = "Authored-By:" <SP> credentials eol empty-line+
+credentials = name+ "<" login "@" host ">"
+empty-line = eol
+eol = <CR>*<LF>
+
+2. *Co-Authored-by* - The commit message co-author.
+These GitHub-recognized attribute allows to create a commit with multiple
+authors. If a message has an empty line followed by 'Co-authored-by: ',
+the bot treats this line and lines below as message trailer. Trailer
+section may contain multiple 'Co-authored-by' attrubutes, but other
+lines starting with /\s*\S*Authored-By/ are regarded as errors.
+The attribute is parsed according to the following ABNF rules:
+co-authors-paragraph = eol empty-line co-author-line+ empty-line\*
+co-author-line = "Co-Authored-By:" <SP> credentials eol
 
 ## Voting and PR approvals
 

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -255,11 +255,10 @@ async function compareCommits(baseRef, headRef) {
     return (await rateLimitedPromise(promise)).status;
 }
 
-async function getCommits(branch, since, author) {
+async function getCommits(branch, since) {
     let params = commonParams();
     params.sha = branch; // sha or branch to start listing commits from
     params.since = since;
-    params.author = author;
     const promise = new Promise( (resolve, reject) => {
         GitHub.authenticate(GitHubAuthentication);
         GitHub.repos.getCommits(params, async (err, res) => {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -711,9 +711,6 @@ class PullRequest {
         // truthy value contains a reason for disabling _pushLabelsToGitHub()
         this._labelPushBan = false;
 
-        // the 'Authored-by' credentials from the PR message or null
-        this._authoredBy = undefined;
-
         this._commitMessage = undefined;
     }
 
@@ -1257,8 +1254,6 @@ class PullRequest {
             return false;
         }
         const result = this._commitMessage.whole() === this._stagedCommit.message;
-        this._warn(this._commitMessage.whole());
-        this._warn(this._stagedCommit.message);
         this._log("staged commit message freshness: " + result);
 
         if (this._commitMessage.author()) {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -933,18 +933,8 @@ class PullRequest {
             this._prMergeable() &&
             this._stagedCommitMetadataIsFresh()) {
 
-            assert(this._mergeCommit);
-            // whether the PR branch has not changed
-            if (this._stagedCommit.tree.sha === this._mergeCommit.tree.sha) {
-                const stagedCommitDate = new Date(this._stagedCommit.committer.date);
-                const prCommitDate = new Date(this._mergeCommit.committer.date);
-                // check that a 'no-change' PR commit did not update the merge commit
-                // (which keeps the old tree object in this case)
-                if (stagedCommitDate >= prCommitDate) {
-                    this._log("the staged commit is fresh");
-                    return true;
-                }
-            }
+            this._log("the staged commit is fresh");
+            return true;
         }
         this._log("the staged commit is stale");
         return false;
@@ -1308,7 +1298,18 @@ class PullRequest {
         if (!authorIsFresh)
             return false;
 
-        return true;
+        const treeShaIsFresh = this._stagedCommit.tree.sha === this._mergeCommit.tree.sha;
+        this._log("staged commit tree sha freshness: " + treeShaIsFresh);
+        if (!treeShaIsFresh)
+            return false;
+
+        const stagedCommitDate = new Date(this._stagedCommit.author.date);
+        const prCommitDate = new Date(this._commitMessage.author().date);
+        // check that a 'no-change' PR commit did not update the merge commit
+        // (which keeps the old tree object in this case)
+        const dateIsFresh = stagedCommitDate >= prCommitDate;
+        this._log("staged commit date freshness: " + dateIsFresh);
+        return dateIsFresh;
     }
 
     async _processStagingStatuses() {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1055,8 +1055,7 @@ class PullRequest {
 
         assert(!this._prState.merged());
 
-        // paranoid null check: must be undefined or non-null
-        this._log("messageValid: " + (this._commitMessage !== undefined && this._commitMessage !== null));
+        this._log("messageValid: " + (this._commitMessage !== undefined));
 
         this._approval = await this._checkApproval();
         this._log("checkApproval: " + this._approval);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -481,12 +481,12 @@ class FieldsTokenizer
             if (/^\s/.test(line))
                 throw new Error(`a field cannot start with whitespace: ${line}`);
 
-            const pos = line.search(':');
+            const pos = line.search(': ');
             if (pos < 0)
-                throw new Error(`a field without a name:value delimiter: '${line}'`);
+                throw new Error(`a field without a name: value delimiter: '${line}'`);
 
             const name = line.substring(0, pos);
-            const value = line.substring(pos+1);
+            const value = line.substring(pos+2).trim();
             if (this._remainingFields.some(el => el.name.toUpperCase() === name.toUpperCase() &&
                         el.value.toUpperCase() === value.toUpperCase())) {
                 throw new Error(`duplicates are not allowed: ${line}`);
@@ -601,6 +601,8 @@ class CommitMessage
             // allow excessively long whitespace-only lines
             // that some copy-pasted PR descriptions may include
             const trimmedLine = this._trim(line);
+
+            // TODO: Allow longer header (and possibly even trailer) lines.
             if (trimmedLine.length > 72)
                 throw new Error(`too long line '${trimmedLine}'`);
         }
@@ -617,7 +619,7 @@ class CommitMessage
     // authorField is a {name, value, raw}
     _parseAuthor(authorField) {
         const trimmedValue = this._trim(authorField.value);
-        const cred = trimmedValue.match(/^ ([\w][^@<>,]*) <(\S+@\S+\.\S+)>$/);
+        const cred = trimmedValue.match(/^([\w][^@<>,]*) <(\S+@\S+\.\S+)>$/);
         if (!cred)
             throw new Error(`unsupported ${authorField.name} value format: ${authorField.value}`);
 
@@ -647,7 +649,7 @@ class CommitMessage
         // index of the last occurrence of '\n\n'
         let trailerCandidateIndex = prDescriptionWithoutHeader.search(/\n\n(?!.*\n\n)/s);
         // Does the text have at most one paragraph?
-        trailerCandidateIndex = trailerCandidateIndex < 0 ? 0 : trailerCandidateIndex + 2
+        trailerCandidateIndex = trailerCandidateIndex < 0 ? 0 : (trailerCandidateIndex + 2);
         const trailerCandidate = prDescriptionWithoutHeader.substring(trailerCandidateIndex);
         if (this._startsWithFieldName(trailerCandidate) !== null) {
             this._parseTrailer(prDescriptionWithoutHeader.substring(trailerCandidateIndex));

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -947,12 +947,12 @@ class PullRequest {
         if (!authoredBy)
             return body;
 
-        const cred = authoredBy[2].match(/(.+)<(.+)>/);
+        const cred = authoredBy[2].match(/(.+)<(\S+@\S+\.\S+)>/);
         if (!cred) {
             this._warn(`Invalid PR message: incorrect 'Authored-by' format`);
             return null;
         } else {
-            let now = new Date();
+            const now = new Date();
             this._authoredBy = {name: cred[1].trim(), email: cred[2].trim(), date: now.toISOString()};
         }
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -562,6 +562,7 @@ class CommitMessage
             // when the message consists of only Authored-by and Co-authored-by lines
             this._extractTrailer(trimmedEndPrDescription);
         } catch (e) {
+            // TODO: supply debugString() prefix
             Log.Logger.info("assuming no trailer: " + e.message);
             this._body = trimmedEndPrDescription;
         }
@@ -1222,7 +1223,7 @@ class PullRequest {
         try {
             this._commitMessage = new CommitMessage(this._rawPr);
         } catch (e) {
-            this._warn("cannot parse commit message: " + e.message + " " + e.stack);
+            this._logEx(e, "cannot parse commit message");
         }
     }
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -505,22 +505,35 @@ class FieldsTokenizer
 class CommitMessage
 {
     constructor(rawPr, defaultAuthor) {
+
         // the (required) commit message title
         this._title = rawPr.title + ' (#' + rawPr.number + ')';
-        // the optional main description part, without header and trailer
+
+        // PR description has three optional parts: [header]+[body]+[trailer]
+        // The parts are separated by empty lines.
+
+        // The header is dedicated to Anubis-recognized/consumed PR metadata.
+        // The commit message only retains the body and the trailer.
+
+        // PR description without the header and trailer parts
         this._body = null;
-        // The optional finalizing description part with GitHub-related attributes,
-        // separated from the body by an empty line.
+
+        // optional commit attributes recognized by GitHub, git, and/or Project
+        // these attributes are partially validated by Anubis
+        // stored in the original text format
         this._trailer = null;
-        // The 'Authored-by' meta information extracted from the optional description header,
-        // separated from the body by an empty line.
-        this._customAuthor = null;
-        // Author in the {name, email, date} format.
-        // The default author will be used in the future commit if the 'Authored-by' attribute is missing.
+
+        // GitHub-suggested commit author
+        // uses {name, email, date} format
         assert(defaultAuthor);
         this._defaultAuthor = defaultAuthor;
 
-        // last paragraphs started with these expressions are not trailers
+        // optional commit author specified by 'Authored-by' header field
+        // uses {name, email} format
+        // overwrites this._defaultAuthor's name and email
+        this._customAuthor = null;
+
+        // a paragraph that starts with one of these expressions is not a trailer
         this.phonyTrailers = [
             /^typo:/i,
             /^np:/i,

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -581,7 +581,7 @@ class CommitMessage
     _paragraphLabel(str) {
         if (/^\s{4}/.test(str)) // not a regular paragraph but a quotation
             return null;
-        const rawLabel = str.match(/^\s*(\S+)\s*:/);
+        const rawLabel = str.match(/^\s*(\S+):/);
         if (!rawLabel)
             return null;
         const label = rawLabel[1].toLowerCase();

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -457,8 +457,13 @@ class BranchPosition
 // Forward iterator for fields in the 'name:value' format.
 class FieldsTokenizer
 {
-    constructor(str) {
+    constructor(str, allowDuplicates = true) {
         this._lines = str.split('\n');
+        if (!allowDuplicates) {
+            const uniqueLines = [...new Set(this._lines)];
+            if (this._lines.length !== uniqueLines.length)
+                throw new Error(`duplicate fields are not allowed`);
+        }
     }
 
     // Extracts the next line from the input and checks that it matches the
@@ -633,7 +638,7 @@ class CommitMessage
 
     _parseTrailer(trailerRaw) {
         const trailer = this._trim(trailerRaw);
-        let tokenizer = new FieldsTokenizer(trailer);
+        let tokenizer = new FieldsTokenizer(trailer, false);
 
         if (tokenizer.atEnd())
             throw new Error(`an empty trailer`);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -533,17 +533,36 @@ class CommitMessage
         // overwrites this._defaultAuthor's name and email
         this._customAuthor = null;
 
-        // a paragraph that starts with one of these expressions is not a trailer
+        // We want to validate all trailers and only trailers for formatting
+        // errors. Unfortunately, there is no reliable way to detect trailer
+        // presence. Thus, we will miss some trailers (and merge some PRs with
+        // buggy trailers), and we will validate some non-trailers (and block
+        // some valid PRs). The current implementation considers excessive
+        // blocking to be the lesser of the two evils: We treat any last
+        // paragraph that starts with /\S+:/ as a trailer _unless_ it starts
+        // with one of these common expressions.
         this.phonyTrailers = [
-            /^typo:/i,
-            /^np:/i,
+            // common paragraph labels or introductory words
+            /^TODO:/i,
+            /^XXX:/i,
+            /^Motivation:/i,
+            /^Context:/i,
+            /^Note:/i,
+            /^NP:/i,
+            /^Typo:/i,
+
+            // quoted messages (that should have been indented but were not)
             /^error:/i,
-            /^todo:/i,
-            /^motivation:/i,
-            /^note:/i,
-            /^\[\^\d+\]:/,  // GitHub footnotes
-            /^\w+::/,       // method names
-            /^http[s]?:/i
+            /^warning:/i,
+
+            // e.g., a C++ class member name or a name inside a namespace
+            /^\w+::/,
+
+            // raw URLs
+            /^http[s]?:/i,
+
+            // markdown citations/references and footnotes
+            /^\[\^\d+\]:/
         ];
 
         this._checkRaw(this._title);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -558,8 +558,8 @@ class CommitMessage
             // e.g., a C++ class member name or a name inside a namespace
             /^\w+::/,
 
-            // raw URLs
-            /^http[s]?:/i,
+            // raw HTTP URLs
+            new RegExp('^http[s]?://', 'i'),
 
             // markdown citations/references and footnotes
             /^\[\^\d+\]:/

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -571,7 +571,7 @@ class CommitMessage
     }
 
     _findMisplacedAuthor(str) {
-        const misplacedAuthor = /^\s*\S*[aA]uthored-[bB]y/m;
+        const misplacedAuthor = /^\s*\S*[aA]uthored[-_]?[bB]y/m;
         return str.search(misplacedAuthor) >= 0;
     }
 }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -498,14 +498,14 @@ class CommitMessage
     constructor(rawPr, defaultAuthor) {
         // the (required) commit message title
         this._title = rawPr.title + ' (#' + rawPr.number + ')';
-        // the main description part, without header and trailer
-        this._body = undefined;
+        // the optional main description part, without header and trailer
+        this._body = null;
         // The optional finalizing description part with GitHub-related attributes,
         // separated from the body by an empty line.
-        this._trailer = undefined;
+        this._trailer = null;
         // The 'Authored-by' meta information extracted from the optional description header,
         // separated from the body by an empty line.
-        this._customAuthor = undefined;
+        this._customAuthor = null;
         // Author in the {name, email, date} format.
         // The default author will be used in the future commit if the 'Authored-by' attribute is missing.
         assert(defaultAuthor);
@@ -521,9 +521,9 @@ class CommitMessage
     whole() {
         assert(this._title.length); // the only required part
         let message = this._title;
-        if (this._body)
+        if (this._body !== null)
             message += '\n\n' + this._body;
-        if (this._trailer)
+        if (this._trailer !== null)
             message += '\n\n' + this._trailer;
         return message;
     }
@@ -531,7 +531,7 @@ class CommitMessage
     // the future commit author in the {name, email, date} format
     author()
     {
-        if (!this._customAuthor)
+        if (this._customAuthor === null)
             return this._defaultAuthor;
         return {name: this._customAuthor.name, email: this._customAuthor.email, date: this._defaultAuthor.date};
     }
@@ -582,8 +582,6 @@ class CommitMessage
             Log.Logger.info("assuming no trailer: " + e.message);
             this._parseBody(prDescriptionWithoutHeader);
         }
-
-        assert(this._body !== undefined && this._body !== null);
     }
 
     // authorField is a {name, value, raw}
@@ -627,8 +625,10 @@ class CommitMessage
 
     _parseBody(prDescriptionWithoutHeaderAndTrailerRaw) {
         const prDescriptionWithoutHeaderAndTrailer = this._trim(prDescriptionWithoutHeaderAndTrailerRaw);
-        this._checkForTypos(prDescriptionWithoutHeaderAndTrailer);
-        this._body = prDescriptionWithoutHeaderAndTrailer;
+        if (prDescriptionWithoutHeaderAndTrailer.length > 0) {
+            this._checkForTypos(prDescriptionWithoutHeaderAndTrailer);
+            this._body = prDescriptionWithoutHeaderAndTrailer;
+        }
     }
 
     _parseTrailer(trailerRaw) {
@@ -648,7 +648,8 @@ class CommitMessage
             }
         }
 
-        this._trailer = trailer;
+        if (trailer.length > 0)
+            this._trailer = trailer;
     }
 
     // checks the PR message (or its part) for some common/expected typos that may occur

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -888,12 +888,12 @@ class PullRequest {
     _validatePrMessageAttributes() {
         const origBody = this._preprocessedPrBody();
         assert(origBody);
-        const misplacedAuthor = /^\S*[aA]uthored-[bB]y/m;
+        const misplacedAuthor = /^\s*\S*[aA]uthored-[bB]y/m;
         const trailerIndex = origBody.search(/\n\nCo-authored-by: /);
         const body = (trailerIndex >= 0) ? origBody.substring(0, trailerIndex) : origBody;
         const misplacedAuthorIndex = body.search(misplacedAuthor);
         if (misplacedAuthorIndex >= 0) {
-            this._warn(`Invalid PR message: a misplaced '*Authored-by' attribute in the message body at ${misplacedAuthorIndex}'`);
+            this._warn(`Invalid PR message: a misplaced '*Authored-by' attribute in the message body at ${misplacedAuthorIndex} position`);
             return false;
         }
 
@@ -988,9 +988,7 @@ class PullRequest {
         assert(lineEnd >= 0);
         assert(this._authoredByCache === undefined);
         this._authoredByCache = this._parseAuthor(attr, body.substring(attr.length, lineEnd));
-        if (!this._authoredByCache)
-            return null;
-        return body.substring(lineEnd+1); // an empty string if overruning the body size
+        return this._authoredByCache ? body.substring(lineEnd).trim() : null;
     }
 
     _createdAt() { return this._rawPr.created_at; }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -959,7 +959,7 @@ class PullRequest {
     }
 
     _parseAuthor(attr, str) {
-        const cred = str.match(/^([\w+\s]+) <(\S+@\S+\.\S+)>$/);
+        const cred = str.match(/^([\w][^@<>,]*) <(\S+@\S+\.\S+)>$/);
         if (!cred) {
             this._warn(`Invalid PR message: cannot parse ${attr} line: ${str}`);
             return null;

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -624,7 +624,7 @@ class CommitMessage
 
     // authorField is a {name, value, raw}
     _parseAuthor(authorField) {
-        const cred = authorField.value.match(/^([\w][^@<>,]*) <(\S+@\S+\.\S+)>$/);
+        const cred = authorField.value.match(/^([\w][^@<>,]*)\s<(\S+@\S+\.\S+)>$/);
         if (!cred)
             throw new Error(`unsupported ${authorField.name} value format: ${authorField.value}`);
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -457,6 +457,7 @@ class BranchPosition
 // Forward iterator for fields in the 'name:value' format.
 class FieldsTokenizer
 {
+    // input string and an array of allowed attributes
     constructor(str, allowedAttributes) {
         this._lines = str.split('\n');
         // supported attributes
@@ -485,9 +486,9 @@ class FieldsTokenizer
         return this._lines.length === 0;
     }
 
-    // returns the unparsed (yet) string with removed leading empty lines
+    // returns the unparsed (yet) string
     remaining() {
-        return this._lines.join('\n').replace(/^\s*\n+/g, '');
+        return this._lines.join('\n');
     }
 }
 
@@ -529,9 +530,9 @@ class CommitMessage
         assert(this._author !== null && this._body !== null && this._trailer !== null);
         let message = this._title;
         if (this._body)
-            message += '\n\n' + this._body.trimEnd();
+            message += '\n\n' + this._body;
         if (this._trailer)
-            message += '\n\n' + this._trailer.trim();
+            message += '\n\n' + this._trailer;
         return message;
     }
 
@@ -599,7 +600,7 @@ class CommitMessage
             const trailerIndex = this._body.search(/\n\n(?!.+\n\n)/s);
             if (trailerIndex >= 0) {
                 this._trailer = this._body.substring(trailerIndex).trim();
-                this._body = this._body.substring(0, trailerIndex);
+                this._body = this._body.substring(0, trailerIndex); // trim in _parseBody()
                 this._parseTrailer();
             }
 
@@ -632,6 +633,9 @@ class CommitMessage
         }
         if (tokenizer.nextField() !== null)
             throw new Error(`the message body can contain only one '${attr}' attribute at the beginning`);
+        // Remove leading empty lines.
+        // Do not use trim() to preserve the first line indentation (if any).
+        this._body = this._body.replace(/^\s*\n+/g, '').trimEnd();
     }
 
     _parseTrailer() {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1173,8 +1173,13 @@ class PullRequest {
 
     // Whether the commit message configuration remained intact since staging.
     _messageIsFresh() {
-        return this._commitMessage.valid() &&
-              (this._commitMessage.whole() === this._stagedCommit.message);
+        if (!this._commitMessage.valid()) {
+            this._log("staged commit message is invalid (and stale)");
+            return false;
+        }
+        const result = this._commitMessage.whole() === this._stagedCommit.message;
+        this._log("staged commit message freshness: " + result);
+        return result;
     }
 
     async _processStagingStatuses() {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -497,7 +497,7 @@ class FieldsTokenizer
 
     atEnd() { return this._remainingFields.length === 0; }
 
-    // returns the (yet) unparsed string
+    // zero or more paragraphs after the parsed fields and field terminator
     remaining() { return this._lines.join('\n'); }
 }
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -484,8 +484,15 @@ class CommitMessage
         return message.trim();
     }
 
-    // The author specified in the the Authoredby attribute in {name, email, date} format.
-    author() { return this._author; }
+    // the author specified in the the Authoredby attribute in {name, email, date} format
+    // or mergeCommitAuthor
+    author(mergeCommitAuthor)
+    {
+        if (!this._author)
+            return mergeCommitAuthor;
+        this._author.date = mergeCommitAuthor.date;
+        return this._author;
+    }
 
     // returns the position of the first non-ASCII_printable character (or -1)
     _invalidCharacterPosition(str) {
@@ -552,7 +559,7 @@ class CommitMessage
             return null;
         }
         const now = new Date();
-        return {name: cred[1].trim(), email: cred[2].trim(), date: now.toISOString()};
+        return {name: cred[1].trim(), email: cred[2].trim(), date: null};
     }
 
     _parseTrailer(trailer) {
@@ -1345,7 +1352,7 @@ class PullRequest {
         if (this._dryRun("create staged commit"))
             throw this._exObviousFailure("dryRun");
 
-        const author = this._commitMessage.author() ? this._commitMessage.author() : mergeCommit.author;
+        const author = this._commitMessage.author(mergeCommit.author);
         this._stagedCommit = await GH.createCommit(mergeCommit.tree.sha, this._commitMessage.whole(), [baseSha], author, committer);
 
         assert(!this._stagingBanned);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1255,6 +1255,8 @@ class PullRequest {
         }
         const result = this._commitMessage.whole() === this._stagedCommit.message;
         this._log("staged commit message freshness: " + result);
+        if (!result)
+            return false;
 
         if (this._commitMessage.author()) {
             const oldAuthor = this._stagedCommit.author;
@@ -1265,7 +1267,7 @@ class PullRequest {
                 return false;
         }
 
-        return result;
+        return true;
     }
 
     async _processStagingStatuses() {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -882,7 +882,7 @@ class PullRequest {
         }
 
         let body = this._preprocessedPrBody();
-        const trailer = body.match(/\n\nCo-authored-by/);
+        const trailer = body.match(/\n\nCo-authored-by: /);
         if (trailer)
             body = body.substring(0, trailer.index);
         if (body.match(/^\S*[aA]uthored-[bB]y/m)) {
@@ -956,7 +956,7 @@ class PullRequest {
             this._authoredBy = {name: cred[1].trim(), email: cred[2].trim(), date: now.toISOString()};
         }
 
-        return body.substring(authoredBy[0].length);
+        return body.substring(authoredBy[0].length).trim();
     }
 
     _createdAt() { return this._rawPr.created_at; }
@@ -1117,7 +1117,7 @@ class PullRequest {
         const pr = await GH.getPR(this._prNumber(), waitForMergeable);
         assert(pr.number === this._prNumber());
         this._rawPr = pr;
-        this._processPrBody();
+        this._preprocessedPrBody(); // cache and ignore the result (for now)
     }
 
     // Whether the commit message configuration remained intact since staging.

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -583,14 +583,14 @@ class CommitMessage
         this._checkRaw(prDescription);
         const prDescriptionWithoutHeader = this._extractHeader(prDescription);
 
+        let prDescriptionWithoutHeaderAndTrailer = prDescriptionWithoutHeader; // may be adjusted below
         try {
-            const prDescriptionWithoutHeaderAndTrailer = this._extractTrailer(prDescriptionWithoutHeader);
-            this._parseBody(prDescriptionWithoutHeaderAndTrailer);
+            prDescriptionWithoutHeaderAndTrailer = this._extractTrailer(prDescriptionWithoutHeader);
         } catch (e) {
             // TODO: supply debugString() prefix
             Log.Logger.info("assuming no trailer: " + e.message);
-            this._parseBody(prDescriptionWithoutHeader);
         }
+        this._parseBody(prDescriptionWithoutHeaderAndTrailer);
     }
 
     // authorField is a {name, value, raw}

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -626,8 +626,7 @@ class CommitMessage
 
     // authorField is a {name, value, raw}
     _parseAuthor(authorField) {
-        const trimmedValue = this._trim(authorField.value);
-        const cred = trimmedValue.match(/^([\w][^@<>,]*) <(\S+@\S+\.\S+)>$/);
+        const cred = authorField.value.match(/^([\w][^@<>,]*) <(\S+@\S+\.\S+)>$/);
         if (!cred)
             throw new Error(`unsupported ${authorField.name} value format: ${authorField.value}`);
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -634,6 +634,7 @@ class CommitMessage
         return {name: cred[1].trim(), email: cred[2].trim()};
     }
 
+    // returns the passed description without header (if any)
     _extractHeader(prDescriptionRaw) {
         const prDescription = this._trim(prDescriptionRaw);
         const headerFieldName = 'Authored-by';
@@ -651,6 +652,7 @@ class CommitMessage
         }
     }
 
+    // returns the passed description without trailer (if any)
     _extractTrailer(prDescriptionWithoutHeaderRaw) {
         const prDescriptionWithoutHeader = this._trim(prDescriptionWithoutHeaderRaw);
         // index of the last occurrence of '\n\n'
@@ -666,6 +668,7 @@ class CommitMessage
         return prDescriptionWithoutHeader;
     }
 
+    // parses the extracted body into this._body
     _parseBody(prDescriptionWithoutHeaderAndTrailerRaw) {
         const prDescriptionWithoutHeaderAndTrailer = this._trim(prDescriptionWithoutHeaderAndTrailerRaw);
         if (prDescriptionWithoutHeaderAndTrailer.length > 0) {
@@ -674,6 +677,7 @@ class CommitMessage
         }
     }
 
+    // parses the extracted trailer into this._trailer
     _parseTrailer(trailerRaw) {
         const trailer = this._trim(trailerRaw);
         let tokenizer = new FieldsTokenizer(trailer);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -467,7 +467,6 @@ class FieldsTokenizer
     nextField() {
         assert(!this.atEnd());
         const line = this._lines.shift();
-        // treat an empty line as the end of input
         assert(line.trim().length > 0);
 
         const pos = line.search(':');
@@ -479,6 +478,7 @@ class FieldsTokenizer
 
     // whether we are at the end of input
     atEnd() {
+        // treat an empty line as the end of input
         return this._lines.length === 0 || this._lines[0].trim().length === 0;
     }
 
@@ -494,12 +494,13 @@ class CommitMessage
     constructor(rawPr) {
         // the (required) commit message title
         this._title = rawPr.title + ' (#' + rawPr.number + ')';
-        // the (optional) message body without optional trailer, may be missing
+        // the main message part, without header and trailer
         this._body = undefined;
-        // The (optional) finalizing message part with GitHub-related attributes,
+        // The optional finalizing message part with GitHub-related attributes,
         // separated from the body by an empty line.
         this._trailer = undefined;
-        // the (optional) Authored-by meta information extracted from the PR description header
+        // The 'Authored-by' meta information extracted from the optional message header,
+        // separated from the body by an empty line.
         this._author = undefined;
 
         if (rawPr.body !== undefined && rawPr.body !== null) {
@@ -1413,6 +1414,7 @@ class PullRequest {
         if (this._dryRun("create staged commit"))
             throw this._exObviousFailure("dryRun");
 
+        assert(this._commitMessage);
         const author = this._commitMessage.createAuthor(mergeCommit.author);
         this._stagedCommit = await GH.createCommit(mergeCommit.tree.sha, this._commitMessage.whole(), [baseSha], author, committer);
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -933,12 +933,11 @@ class PullRequest {
             this._prMergeable() &&
             this._stagedCommitMetadataIsFresh()) {
 
-            const prMergeSha = await GH.getReference(this._mergePath());
-            const prCommit = await GH.getCommit(prMergeSha);
+            assert(this._mergeCommit);
             // whether the PR branch has not changed
-            if (this._stagedCommit.tree.sha === prCommit.tree.sha) {
+            if (this._stagedCommit.tree.sha === this._mergeCommit.tree.sha) {
                 const stagedCommitDate = new Date(this._stagedCommit.committer.date);
-                const prCommitDate = new Date(prCommit.committer.date);
+                const prCommitDate = new Date(this._mergeCommit.committer.date);
                 // check that a 'no-change' PR commit did not update the merge commit
                 // (which keeps the old tree object in this case)
                 if (stagedCommitDate >= prCommitDate) {
@@ -1281,7 +1280,7 @@ class PullRequest {
         this._rawPr = pr;
 
         if (this._prMergeable()) {
-            const mergeSha = await GH.getReference("pull/" + this._prNumber() + "/merge");
+            const mergeSha = await GH.getReference(this._mergePath());
             this._mergeCommit = await GH.getCommit(mergeSha);
             try {
                 this._commitMessage = new CommitMessage(this._rawPr, this._mergeCommit.author);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -491,6 +491,9 @@ class FieldsTokenizer
                 throw new Error(`a field without a name: value delimiter: '${line}'`);
 
             const name = line.substring(0, pos);
+            if (/\s/.test(name))
+                throw new Error(`the field name cannot contain a whitespace: ${name}`);
+
             const value = line.substring(pos+2).trim();
             if (this._remainingFields.some(el => el.name.toUpperCase() === name.toUpperCase() &&
                         el.value.toUpperCase() === value.toUpperCase())) {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1156,7 +1156,7 @@ class PullRequest {
     async _mergedSomeTimeAgo() {
         const dateSince = this._dateForDaysAgo(100);
         let mergedSha = null;
-        let commits = await GH.getCommits(this._prBaseBranch(), dateSince, this._prAuthor());
+        let commits = await GH.getCommits(this._prBaseBranch(), dateSince);
         for (let commit of commits) {
             const num = Util.ParsePrNumber(commit.commit.message);
             if (num && num === this._prNumber().toString()) {


### PR DESCRIPTION
If the PR description starts with "Authored-By:" attribute, the
specified author credentials are used as the commit author instead of
the ones provided by GitHub (i.e., the PR author). The entire
attribute line (including the trailing empty lines) is removed from
the PR message.

If PR author credentials cannot be parsed, the PR is rejected as having
an invalid description. The PR is rejected also if more than one
'Authored-by' attribute is specified.

Similar checks are applied also to 'Co-authored-by' attributes (coming
in the trailer part of the PR message). The credentials part of
this attribute follows the same syntax, but the trailer may have more
than one 'Co-authored-by'.