### PR TITLE
Allow long header and trailer lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ Co-authored-by: Co-Author Two <user2@host2>
 
 All parts are optional. Header and trailer parts are separated from the
 regular PR description paragraph(s) (or each other) by an empty line.
+The length of each header and trailer line is limited to 512 characters,
+which should be enough to accommodate most long emails/URLs. The length
+of regular paragraphs must conform to the 72 characters/line limitation.
 Additional PR description formatting requirements are documented in the
 "Commit message" section further below.
 
@@ -252,11 +255,12 @@ number appended) and the PR description (without the header, if any) delimited
 by an empty line. Empty and header-only PR descriptions are allowed and result
 in a title-only commit message.
 
-Neither the title nor the description are currently processed to convert
-GitHub markdown to plain text. However, both texts must conform to the
-72 characters/line limit. The automatically added ` #(NNN)` title suffix
-further reduces the maximum PR title length to ~65 characters. PRs violating
-these limits are labeled `M-failed-description` and are not merged.
+Neither the title nor the description are currently processed to convert GitHub
+markdown to plain text. The title must conform to the same 72 characters/line
+limit as regular PR description paragraphs. The automatically added ` #(NNN)`
+title suffix further reduces the maximum PR title length to ~65 characters.
+PRs violating line length limits are labeled `M-failed-description`and are
+not merged.
 
 
 ## Voting and PR approvals

--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ All labels except `M-failed-staging-checks`, `M-failed-staging-other`,
 them useful when determining the current state of a PR.
 
 
+## PR title
+
+PR titles are used as staged commit message title prefixes. Commit
+message titles are limited to 72 characters. The automatically added
+`#(NNNN)` title suffix reduces the maximum PR title length to ~64
+characters. PR titles violating line length limits are labeled
+`M-failed-description` and are not merged.
+
 ## PR description
 
 Pull request description may have up to three kinds of paragraphs: a header,
@@ -190,11 +198,12 @@ Co-authored-by: Co-Author Two <user2@host2>
 
 All parts are optional. Header and trailer parts are separated from the
 regular PR description paragraph(s) (or each other) by an empty line.
+
 The length of each header and trailer line is limited to 512 characters,
 which should be enough to accommodate most long emails/URLs. The length
-of regular paragraphs must conform to the 72 characters/line limitation.
-Additional PR description formatting requirements are documented in the
-"Commit message" section further below.
+of regular paragraphs is limited to 72 characters. PR descriptions
+violating line length limits are labeled `M-failed-description` and are
+not merged.
 
 A header and trailer paragraphs consist of special `name: value` metadata
 fields documented below. Header fields are recognized only by the bot. Some
@@ -256,11 +265,7 @@ by an empty line. Empty and header-only PR descriptions are allowed and result
 in a title-only commit message.
 
 Neither the title nor the description are currently processed to convert GitHub
-markdown to plain text. The title must conform to the same 72 characters/line
-limit as regular PR description paragraphs. The automatically added ` #(NNN)`
-title suffix further reduces the maximum PR title length to ~65 characters.
-PRs violating line length limits are labeled `M-failed-description`and are
-not merged.
+markdown to plain text.
 
 
 ## Voting and PR approvals

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -494,6 +494,12 @@ class FieldsTokenizer
                         el.value.toUpperCase() === value.toUpperCase())) {
                 throw new Error(`duplicates are not allowed: ${line}`);
             }
+
+            const maxLength = 512;
+            const length = (name + ': ' + value).length;
+            if (length > maxLength)
+                throw new Error(`the field is too long: ${length}>${maxLength}`);
+
             this._remainingFields.push({name: name, value: value, raw: line});
         }
     }
@@ -595,11 +601,15 @@ class CommitMessage
             // allow excessively long whitespace-only lines
             // that some copy-pasted PR descriptions may include
             const line = untrimmedLine.trimEnd();
-            // TODO: Allow longer header (and possibly even trailer) lines.
-            this._checkLineLength(line);
             lines.push(line);
         }
         return lines.join('\n');
+    }
+
+    _checkMessageLength(message) {
+        const lines = message.split('\n');
+        for (let line of lines)
+            this._checkLineLength(line);
     }
 
     // removes leading empty lines and trims the end
@@ -683,6 +693,7 @@ class CommitMessage
     _parseBody(prDescriptionWithoutHeaderAndTrailerRaw) {
         const prDescriptionWithoutHeaderAndTrailer = this._trim(prDescriptionWithoutHeaderAndTrailerRaw);
         if (prDescriptionWithoutHeaderAndTrailer.length > 0) {
+            this._checkMessageLength(prDescriptionWithoutHeaderAndTrailer);
             this._checkForTypos(prDescriptionWithoutHeaderAndTrailer);
             this._body = prDescriptionWithoutHeaderAndTrailer;
         }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -454,7 +454,7 @@ class BranchPosition
     }
 }
 
-function checkLineLength(line, limit) {
+function checkLineLength(line, limit = 72) {
     if (line.length > limit)
         throw new Error(`the line is too long ${line.length}>${limit}: ${line}'`);
 }
@@ -555,7 +555,7 @@ class CommitMessage
         this._checkRawCharacters(title);
         // the (required) commit message title
         this._title = title + ' (#' + prNumber + ')';
-        checkLineLength(this._title, 72);
+        checkLineLength(this._title);
     }
 
     // complete message for the future commit
@@ -606,7 +606,7 @@ class CommitMessage
     _checkMessageLength(message) {
         const lines = message.split('\n');
         for (let line of lines)
-            checkLineLength(line, 72);
+            checkLineLength(line);
     }
 
     // removes leading empty lines and trims the end

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -454,6 +454,11 @@ class BranchPosition
     }
 }
 
+function checkLineLength(line, limit) {
+    if (line.length > limit)
+        throw new Error(`the line is too long ${line.length}>${limit}: ${line}'`);
+}
+
 // Forward iterator for fields in the 'name:value' format.
 class FieldsTokenizer
 {
@@ -495,10 +500,7 @@ class FieldsTokenizer
                 throw new Error(`duplicates are not allowed: ${line}`);
             }
 
-            const maxLength = 512;
-            const length = (name + ': ' + value).length;
-            if (length > maxLength)
-                throw new Error(`the field is too long: ${length}>${maxLength}`);
+            checkLineLength(name + ': ' + value, 512);
 
             this._remainingFields.push({name: name, value: value, raw: line});
         }
@@ -553,7 +555,7 @@ class CommitMessage
         this._checkRawCharacters(title);
         // the (required) commit message title
         this._title = title + ' (#' + prNumber + ')';
-        this._checkLineLength(this._title);
+        checkLineLength(this._title, 72);
     }
 
     // complete message for the future commit
@@ -583,11 +585,6 @@ class CommitMessage
             throw new Error(`bad character at ${match.index} in '${line}'`);
     }
 
-    _checkLineLength(line) {
-        if (line.length > 72)
-            throw new Error(`too long line '${line}'`);
-    }
-
     // performs basic checks for a multi-line message
     // trims the end of each message line and returns the result
     _parseRawLines(rawMessage) {
@@ -609,7 +606,7 @@ class CommitMessage
     _checkMessageLength(message) {
         const lines = message.split('\n');
         for (let line of lines)
-            this._checkLineLength(line);
+            checkLineLength(line, 72);
     }
 
     // removes leading empty lines and trims the end


### PR DESCRIPTION
Limited the length of canonical (i.e. post-parsing/formatting)
'name: value' fields to 512 characters.