### PR TITLE
Support GitHub check-runs API

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A bot that merges GitHub pull requests",
   "main": "Main.js",
   "dependencies": {
-    "@octokit/rest": "^14.0.8",
+    "@octokit/rest": "^18.0.0",
     "bunyan": "^1.8.12",
     "github-webhook-handler": "^0.6.0",
     "parse-github-url": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A bot that merges GitHub pull requests",
   "main": "Main.js",
   "dependencies": {
-    "@octokit/rest": "^18.0.0",
+    "@octokit/rest": "^18.12.0",
     "bunyan": "^1.8.12",
     "github-webhook-handler": "^0.6.0",
     "parse-github-url": "^0.3.2",

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -122,6 +122,15 @@ async function getReviews(prNum) {
     return reviews;
 }
 
+async function getCheckRuns(ref) {
+    let params = commonParams();
+    params.ref = ref;
+
+    const checkRuns = await GitHub.paginate(GitHub.rest.checks.listForRef, params);
+    logApiResult(getCheckRuns.name, params, {checkRuns: checkRuns.length});
+    return checkRuns;
+}
+
 async function getStatuses(ref) {
     let params = commonParams();
     params.ref = ref;
@@ -298,6 +307,7 @@ module.exports = {
     getPR: getPR,
     getReviews: getReviews,
     getStatuses: getStatuses,
+    getCheckRuns: getCheckRuns,
     getCommit: getCommit,
     getCommits: getCommits,
     createCommit: createCommit,

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -17,21 +17,6 @@ const ErrorContext = Util.ErrorContext;
 const commonParams = Util.commonParams;
 const logApiResult = Log.logApiResult;
 
-function defaultAppender(allPages, aPage) {
-    allPages.data = allPages.data.concat(aPage.data);
-}
-
-function statusAppender(statusPages, aPage) {
-    let statuses = statusPages.data.statuses;
-    statusPages.data.statuses = statuses.concat(aPage.data.statuses);
-}
-
-function protectedBranchAppender(protectedBranchPages, aPage) {
-    let contexts = protectedBranchPages.data.protection.required_status_checks.contexts;
-    protectedBranchPages.data.protection.required_status_checks.contexts =
-        contexts.concat(aPage.data.protection.required_status_checks.contexts);
-}
-
 // Calculates the artificial delay for an API call (in milliseconds).
 // This delay is required to overcome the "API rate limit exceeded" GitHub error for
 // "core" (non-search) API calls. The current GitHub limitation is 5000/hour,
@@ -280,7 +265,7 @@ async function getProtectedBranchRequiredStatusChecks(branch) {
     params.branch = branch;
 
     const result = await GitHub.rest.repos.getBranch(params);
-    logApiResult(getProtectedBranchRequiredStatusChecks.name, {checks: result.data.protection.required_status_checks.contexts.length});
+    logApiResult(getProtectedBranchRequiredStatusChecks.name, params, {checks: result.data.protection.required_status_checks.contexts.length});
     return (await rateLimitedPromise(result)).protection.required_status_checks.contexts;
 }
 


### PR DESCRIPTION
These GitHub-driven checks are collected and analyzed
the same way as the (old) commit statuses. For simplicity,
check-runs are stored in the same StatusChecks array.

The 'staging_checks' parameter now reflects the total
number of required commit statuses and required GitHub check-runs.

This support is necessary for projects that
require GitHub Actions.