### PR TITLE
Merge unanimously approved PRs without timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,15 @@ single event is sufficient for PR disqualification:
 * A GitHub review request naming a core developer.
 
 A PR without disqualifications is considered approved for merging if
-either of the following two conditions is met:
+either of the following three conditions has been met:
+
+* Unanimous: A PR has been approved by all core developers
+  (`config::core_developers`). There is usually no point in waiting longer if
+  each and every decision maker is happy with the PR state. However, a core
+  developer approving a PR must keep in mind that their action may have an
+  _immediate_ merging effect. For example, "LGTM with changes" approvals may
+  not work as intended (especially when `config::guarded_run` is not enabled,
+  or the PR already has an `M-cleared-for-merge` label).
 
 * Fast track: A PR has at least two approvals
   (`config::sufficient_approvals`) by core developers and has been open

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -172,7 +172,6 @@ async function getReference(ref) {
     let params = commonParams();
     params.ref = ref;
 
-    debugger;
     const result = await GitHub.rest.git.getRef(params);
     logApiResult(getReference.name, params, {ref: result.data.ref, sha: result.data.object.sha});
     return (await rateLimitedPromise(result)).object.sha;

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -172,6 +172,7 @@ async function getReference(ref) {
     let params = commonParams();
     params.ref = ref;
 
+    debugger;
     const result = await GitHub.rest.git.getRef(params);
     logApiResult(getReference.name, params, {ref: result.data.ref, sha: result.data.object.sha});
     return (await rateLimitedPromise(result)).object.sha;

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -877,6 +877,7 @@ class PullRequest {
             return Approval.Suspend("waiting for more votes");
         }
 
+        assert(usersApproved.length <= Config.coreDeveloperIds().size);
         if (usersApproved.length === Config.coreDeveloperIds().size)
             return Approval.GrantNow("approved (unanimously)");
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -837,10 +837,9 @@ class PullRequest {
         // where 'reviewer' is a core developer, 'date' the review date and 'state' is either
         // 'approved' or 'changes_requested'.
         let usersVoted = [];
-        const currentDate = new Date();
         // add the author if needed
         if (this._coreDeveloper('PR author', this._prAuthor(), this._prAuthorId()))
-            usersVoted.push({reviewer: this._prAuthor(), date: currentDate.toISOString(), state: 'approved'});
+            usersVoted.push({reviewer: this._prAuthor(), date: this._createdAt(), state: 'approved'});
 
         // Reviews are returned in chronological order; the list may contain several
         // reviews from the same reviewer, so the actual 'state' is the most recent one.
@@ -878,24 +877,13 @@ class PullRequest {
             return Approval.Suspend("waiting for more votes");
         }
 
-        let staleUnanimousMessage = "";
-        if (usersApproved.length === Config.coreDeveloperIds().size) {
-            const prCommitDate = new Date(this._commitMessage.author().date);
-            for (let userApproved of usersApproved) {
-                const approvedDate = new Date(userApproved.date);
-                if (prCommitDate > approvedDate) {
-                    staleUnanimousMessage = " due to stale unanimous approval";
-                    break;
-                }
-            }
-            if (staleUnanimousMessage === "")
-                return Approval.GrantNow("approved (unanimously)");
-        }
+        if (usersApproved.length === Config.coreDeveloperIds().size)
+            return Approval.GrantNow("approved (unanimously)");
 
         const prAgeMs = new Date() - new Date(this._createdAt());
         if (usersApproved.length >= Config.sufficientApprovals()) {
             if (prAgeMs < Config.votingDelayMin())
-                return Approval.GrantAfterTimeout("waiting for fast track objections" + staleUnanimousMessage, Config.votingDelayMin() - prAgeMs);
+                return Approval.GrantAfterTimeout("waiting for fast track objections", Config.votingDelayMin() - prAgeMs);
             else
                 return Approval.GrantNow("approved");
         }


### PR DESCRIPTION
A PR now becomes immediately 'approved' (without waiting for fast-track
objections) as soon as all of config::core_developers approve the PR.