### PR TITLE
Ignore irrelevant check-runs

### DIFF
--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -973,8 +973,18 @@ class PullRequest {
                 statusChecks.addOptionalStatus(new StatusCheck(st));
         }
 
+        // Returns whole check runs history for the commit.
+        // We need only the freshest checks.
         const checkRuns = await GH.getCheckRuns(this._prHeadSha());
-        for (let st of checkRuns) {
+        // check.id is greater in newer checks
+        const sortedCheckRuns = checkRuns.sort((e1, e2) => parseInt(e1.id) - parseInt(e2.id));
+        let uniqueCheckRuns = [];
+        for (let i = sortedCheckRuns.length -1; i >= 0; --i) {
+            const check = sortedCheckRuns[i];
+            if (!uniqueCheckRuns.some(e => e.name === check.name))
+                uniqueCheckRuns.push(check);
+        }
+        for (let st of uniqueCheckRuns) {
             if (this._contextsRequiredByGitHubConfig.some(el => el.trim() === st.name.trim()))
                 statusChecks.addRequiredStatus(StatusCheck.FromCheckRun(st));
             else


### PR DESCRIPTION
Check Runs API returns the whole set of completed checks for the given
commit. In most cases the set does not contain duplicates because these
checks start only once for the commit. However, sometimes the same
commit may be tested multiple times (e.g., when the PR branch is
force-pushed with the same PR head commit). In this case, all results
are returned, making Anubis assert when checking tests uniqueness. To
avoid this, we need to select only the latest check runs from GitHub.
