### PR TITLE
M-ignored-by-merge-bots: Speeding up PR scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ are satisfied:
 * The PR is approved for merging (see below for voting rules).
 * The PR has a valid title and description (see below for commit message rules).
 * The PR does _not_ have an `M-merged` label.
+* The PR does _not_ have an `M-ignored-by-merge-bots` label.
 
 Satisfying the above conditions results in an attempt to merge the pull
 request (in the ascending PR number order), but merging may still fail.
@@ -161,17 +162,21 @@ request state:
 * `M-cleared-for-merge`: A human has allowed the bot running in
   `config::guarded_run` mode to perform the final merging step --
   updating the target branch. The label has no effect unless the bot is
-  running in that mode. This is the only bot-related label that is meant
+  running in that mode. This is one of the few bot-related label that is meant
   to be set by humans; the bot itself never sets this label. The bot
   removes this label after successfully merging the PR. Avoid setting
   this label unless you are a human responsible for testing the bot.
 * `M-merged`: The PR was successfully merged (and probably closed).
   The bot will not attempt to merge this PR again even if it is
   reopened. The bot never removes this label.
+* `M-ignored-by-merge-bots`: A human marked this PR to be ignored
+   by Anubis: The bot will dismiss this PR until the label is on.
+   This label should be set and unset by humans only.
 
 All labels except `M-failed-staging-checks`, `M-failed-staging-other`,
-`M-cleared-for-merge`, and `M-merged` are ignored by Anubis! Humans may find
-them useful when determining the current state of a PR.
+`M-cleared-for-merge`, `M-merged`, and `M-ignored-by-merge-bots` are ignored
+by Anubis! Humans may find them useful when determining the current
+state of a PR.
 
 
 ## PR title

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ request state:
 * `M-cleared-for-merge`: A human has allowed the bot running in
   `config::guarded_run` mode to perform the final merging step --
   updating the target branch. The label has no effect unless the bot is
-  running in that mode. This is one of a few bot-related label that is meant
+  running in that mode. This is one of a few bot-related label that are meant
   to be set by humans; the bot itself never sets this label. The bot
   removes this label after successfully merging the PR. Avoid setting
   this label unless you are a human responsible for testing the bot.

--- a/README.md
+++ b/README.md
@@ -162,16 +162,17 @@ request state:
 * `M-cleared-for-merge`: A human has allowed the bot running in
   `config::guarded_run` mode to perform the final merging step --
   updating the target branch. The label has no effect unless the bot is
-  running in that mode. This is one of the few bot-related label that is meant
+  running in that mode. This is one of a few bot-related label that is meant
   to be set by humans; the bot itself never sets this label. The bot
   removes this label after successfully merging the PR. Avoid setting
   this label unless you are a human responsible for testing the bot.
 * `M-merged`: The PR was successfully merged (and probably closed).
   The bot will not attempt to merge this PR again even if it is
   reopened. The bot never removes this label.
-* `M-ignored-by-merge-bots`: A human marked this PR to be ignored
-   by Anubis: The bot will dismiss this PR until the label is on.
-   This label should be set and unset by humans only.
+* `M-ignored-by-merge-bots`: A human marked the PR to be ignored
+   by Anubis: The bot does not modify or merge PRs with this label.
+   This label should be set and removed by humans. Anubis does not
+   set and never removes this label.
 
 All labels except `M-failed-staging-checks`, `M-failed-staging-other`,
 `M-cleared-for-merge`, `M-merged`, and `M-ignored-by-merge-bots` are ignored

--- a/src/Config.js
+++ b/src/Config.js
@@ -119,6 +119,8 @@ class ConfigOptions {
     clearedForMergeLabel() { return "M-cleared-for-merge"; }
     // whether the PR was abandoned due to a stale staged commit
     abandonedStagingChecksLabel() { return "M-abandoned-staging-checks"; }
+    // whether this PR is marked by a human to be skipped
+    ignoredByMergeBotsLabel() { return "M-ignored-by-merge-bots"; }
 
     // an URL of the description of the approval test status
     approvalUrl() { return this._approvalUrl; }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1079,7 +1079,7 @@ class PullRequest {
             throw this._exLostControl("premature " + Config.mergedLabel());
 
         if (this._labels.has(Config.ignoredByMergeBotsLabel()))
-            throw this._exLostControl("unexpected " + Config.mergedLabel());
+            throw this._exLostControl("unexpected " + Config.ignoredByMergeBotsLabel());
     }
 
     // whether the PR should be staged (including re-staged)
@@ -1761,7 +1761,8 @@ class PullRequest {
         return problem;
     }
 
-    // somebody else appears to perform Anubis-only PR manipulations
+    // Anubis is explicitly prohibited from manipulating this PR or
+    // somebody else appears to perform Anubis-only PR manipulations.
     // minimize changes to avoid conflicts (but do not block other PRs)
     _exLostControl(why) {
         assert(arguments.length === 1);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1761,8 +1761,9 @@ class PullRequest {
         return problem;
     }
 
-    // Anubis is explicitly prohibited from manipulating this PR or
-    // somebody else appears to perform Anubis-only PR manipulations.
+    // After it started processing a PR, Anubis was prohibited from 
+    // manipulating that PR or discovered a concurrent Anubis-only PR
+    // manipulation (evidently performed by somebody else).
     // minimize changes to avoid conflicts (but do not block other PRs)
     _exLostControl(why) {
         assert(arguments.length === 1);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1077,6 +1077,9 @@ class PullRequest {
 
         if (this._labels.has(Config.mergedLabel()))
             throw this._exLostControl("premature " + Config.mergedLabel());
+
+        if (this._labels.has(Config.ignoredByMergeBotsLabel()))
+            throw this._exLostControl("unexpected " + Config.mergedLabel());
     }
 
     // whether the PR should be staged (including re-staged)

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -13,6 +13,7 @@ class PrMerger {
     constructor() {
         this._total = 0; // the number of open PRs received from GitHub
         this._errors = 0; // the number of PRs with processing failures
+        this._ignored = 0; // the number of ignored PRs (due to human markings)
         this._todo = null; // raw PRs to be processed
     }
 
@@ -33,6 +34,11 @@ class PrMerger {
         while (this._todo.length) {
             try {
                 const rawPr = this._todo.shift();
+                if (rawPr.labels.some(el => el.name === Config.ignoredByMergeBotsLabel())) {
+                    this._ignored++;
+                    Logger.info(`Skipping PR${rawPr.number} due to ${Config.ignoredByMergeBotsLabel()} label`);
+                    continue;
+                }
                 const result = await MergeContext.Process(rawPr, somePrWasStaged);
                 assert(!somePrWasStaged || !result.prStaged());
                 somePrWasStaged = somePrWasStaged || result.prStaged();
@@ -47,7 +53,7 @@ class PrMerger {
         if (this._errors)
             throw new Error(`Failed to process ${this._errors} out of ${this._total} PRs.`);
 
-        Logger.info("Successfully processed all " + this._total + " PRs.");
+        Logger.info("Successfully processed all " + this._total + " PRs, analyzed/skipped: " + (this._total - this._ignored) + "/" + this._ignored);
         return minDelay;
     }
 

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -34,11 +34,13 @@ class PrMerger {
         while (this._todo.length) {
             try {
                 const rawPr = this._todo.shift();
+
                 if (rawPr.labels.some(el => el.name === Config.ignoredByMergeBotsLabel())) {
                     this._ignored++;
-                    Logger.info(`Skipping PR${rawPr.number} due to ${Config.ignoredByMergeBotsLabel()} label`);
+                    Logger.info(`Ignoring PR${rawPr.number} due to ${Config.ignoredByMergeBotsLabel()} label`);
                     continue;
                 }
+
                 const result = await MergeContext.Process(rawPr, somePrWasStaged);
                 assert(!somePrWasStaged || !result.prStaged());
                 somePrWasStaged = somePrWasStaged || result.prStaged();
@@ -53,7 +55,7 @@ class PrMerger {
         if (this._errors)
             throw new Error(`Failed to process ${this._errors} out of ${this._total} PRs.`);
 
-        Logger.info("Successfully processed all " + this._total + " PRs, analyzed/skipped: " + (this._total - this._ignored) + "/" + this._ignored);
+        Logger.info("Successfully handled all " + this._total + " PRs, processed/ignored: " + (this._total - this._ignored) + "/" + this._ignored);
         return minDelay;
     }
 


### PR DESCRIPTION
PRs marked with this label are not subject for bot analysis.
The label is set/unset by humans only.