### PR TITLE
Do not ignore staged PRs

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -78,6 +78,7 @@ WebhookHandler.on('workflow_run', HandlerWrap((ev) => {
         Logger.info("workflow_run event:", e.head_sha);
         // e.pull_requests is empty for the staged commit
         if (e.head_branch === Config.stagingBranch()) {
+            assert(!e.pull_requests.length);
             return Util.PrId.Sha(e.head_sha);
         }
         if (!e.pull_requests.length) {
@@ -96,6 +97,7 @@ WebhookHandler.on('check_run', HandlerWrap((ev) => {
         Logger.info("check_run event:", e.head_sha);
         // e.check_suite.pull_requests is empty for the staged commit
         if (e.check_suite.head_branch === Config.stagingBranch()) {
+            assert(!e.check_suite.pull_requests.length);
             return Util.PrId.Sha(e.head_sha);
         }
         if (!e.check_suite.pull_requests.length) {

--- a/src/Main.js
+++ b/src/Main.js
@@ -80,11 +80,6 @@ WebhookHandler.on('push', (ev) => {
 WebhookHandler.on('workflow_run', (ev) => {
     const e = ev.payload.workflow_run;
     Logger.info("workflow_run event:", e.head_sha);
-    // e.pull_requests is empty for the staged commit
-    if (e.head_branch === Config.stagingBranch()) {
-        Merger.run([e.head_sha]);
-        return;
-    }
     if (!e.pull_requests.length) {
         Logger.warn("workflow_run event: pull_requests array is empty");
         Merger.run([null]);
@@ -97,11 +92,6 @@ WebhookHandler.on('workflow_run', (ev) => {
 WebhookHandler.on('check_run', (ev) => {
     const e = ev.payload.check_run;
     Logger.info("check_run event:", e.head_sha);
-    // e.check_suite.pull_requests is empty for the staged commit
-    if (e.check_suite.head_branch === Config.stagingBranch()) {
-        Merger.run([e.head_sha]);
-        return;
-    }
     if (!e.check_suite.pull_requests.length) {
         Logger.warn("check_run event: pull_requests array is empty");
         Merger.run([null]);

--- a/src/Main.js
+++ b/src/Main.js
@@ -52,7 +52,7 @@ WebhookHandler.on('status', (anEv) => {
     const e = ev.payload;
     Logger.info("status event:", e.id, e.sha, e.context, e.state);
     const branches = Array.from(e.branches, b => b.name);
-    if (branches.includes(Config.stagingBranch())) {
+    if (branches.length === 1 && branches[0] === Config.stagingBranch()) {
         const message = e.commit.commit.message;
         const prNum = Util.ParsePrNumber(message);
         if (prNum === null) {

--- a/src/Main.js
+++ b/src/Main.js
@@ -22,28 +22,28 @@ WebhookHandler.on('error', (err) => {
 WebhookHandler.on('pull_request_review', (ev) => {
     const pr = ev.payload.pull_request;
     Logger.info("pull_request_review event:", ev.payload.id, pr.number, pr.head.sha, pr.state);
-    Merger.run();
+    Merger.run(null, "pull_request_review", pr);
 });
 
 // https://developer.github.com/v3/activity/events/types/#pullrequestevent
 WebhookHandler.on('pull_request', (ev) => {
     const pr = ev.payload.pull_request;
     Logger.info("pull_request event:", ev.payload.id, pr.number, pr.head.sha, pr.state);
-    Merger.run();
+    Merger.run(null, "pull_request", pr);
 });
 
 // https://developer.github.com/v3/activity/events/types/#statusevent
 WebhookHandler.on('status', (ev) => {
     const e = ev.payload;
     Logger.info("status event:", e.id, e.sha, e.context, e.state);
-    Merger.run();
+    Merger.run(null, "status", e);
 });
 
 // https://developer.github.com/v3/activity/events/types/#pushevent
 WebhookHandler.on('push', (ev) => {
     const e = ev.payload;
     Logger.info("push event:", e.ref);
-    Merger.run();
+    Merger.run(null, "push", e);
 });
 
 WebhookHandler.on('ping', (ev) => {

--- a/src/Main.js
+++ b/src/Main.js
@@ -90,7 +90,7 @@ WebhookHandler.on('workflow_run', HandlerWrap((ev) => {
 // https://docs.github.com/en/webhooks/webhook-events-and-payloads#check_run
 WebhookHandler.on('check_run', HandlerWrap((ev) => {
     const e = ev.payload.check_run;
-    Logger.info("check_run event:", e.head_sha);
+    Logger.info("check_run event:", e.check_suite.head_sha);
 
     if (e.check_suite.pull_requests.length) {
         const list = Array.from(e.check_suite.pull_requests, v => v.number);
@@ -98,10 +98,10 @@ WebhookHandler.on('check_run', HandlerWrap((ev) => {
     }
 
     if (e.check_suite.head_branch === Config.stagingBranch()) {
-        return Util.PrId.Sha(e.head_sha);
+        return Util.PrId.Sha(e.check_suite.head_sha);
     }
     // check runs for other non-PR branches (e.g., master) are not associated with PRs
-    Logger.info("check_run event: no PR for", e.head_sha);
+    Logger.info("check_run event: no PR for", e.check_suite.head_sha);
     return [];
 }));
 

--- a/src/Main.js
+++ b/src/Main.js
@@ -1,3 +1,4 @@
+const assert = require('assert');
 const createHandler = require('github-webhook-handler');
 const Config = require('./Config.js');
 const Log = require('./Logger.js');
@@ -19,50 +20,48 @@ WebhookHandler.on('error', (err) => {
    Logger.error('Error:', err.message);
 });
 
-function HandlerWrap(ev, handler) {
-    let prIds = null;
-    try {
-        prIds = handler(ev);
-        assert(prIds);
-        if (prIds.length === 0)
-            return;
-    } catch (err) {
-        Logger.error("Error in", err.message);
-    }
-    Merger.run(prIds);
+function HandlerWrap(handler) {
+    return (ev) => {
+        let prIds = null;
+        try {
+            prIds = handler(ev);
+            assert(prIds);
+            if (prIds.length === 0)
+                return;
+        } catch (err) {
+            Logger.error("Error in", err.message);
+        }
+        Merger.run(prIds);
+    };
 }
 
 // https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent
-WebhookHandler.on('pull_request_review', (anEv) => {
-    HandlerWrap(anEv, (ev) => {
+WebhookHandler.on('pull_request_review', HandlerWrap((ev) => {
         const pr = ev.payload.pull_request;
         Logger.info("pull_request_review event:", ev.payload.id, pr.number, pr.head.sha, pr.state);
         return Util.PrId.PrNum(pr.number);
-    });
-});
+    })
+);
 
 // https://developer.github.com/v3/activity/events/types/#pullrequestevent
-WebhookHandler.on('pull_request', (anEv) => {
-    HandlerWrap(anEv, (ev) => {
+WebhookHandler.on('pull_request', HandlerWrap((ev) => {
         const pr = ev.payload.pull_request;
         Logger.info("pull_request event:", ev.payload.id, pr.number, pr.head.sha, pr.state);
         return Util.PrId.PrNum(pr.number);
-    });
-});
+    })
+);
 
 // https://developer.github.com/v3/activity/events/types/#statusevent
-WebhookHandler.on('status', (anEv) => {
-    HandlerWrap(anEv, (ev) => {
+WebhookHandler.on('status', HandlerWrap((ev) => {
         const e = ev.payload;
         Logger.info("status event:", e.id, e.sha, e.context, e.state);
         const branches = Array.from(e.branches, b => b.name);
         return Util.PrId.BranchList(branches, e.commit.commit.message);
-    });
-});
+    })
+);
 
 // https://developer.github.com/v3/activity/events/types/#pushevent
-WebhookHandler.on('push', (anEv) => {
-    HandlerWrap(anEv, (ev) => {
+WebhookHandler.on('push', HandlerWrap((ev) => {
         const e = ev.payload;
         Logger.info("push event:", e.ref);
 
@@ -70,12 +69,11 @@ WebhookHandler.on('push', (anEv) => {
         const parts = e.ref.split('/');
         const branch = parts[parts.length-1];
         return Util.PrId.BranchList([branch], e.head_commit ? e.head_commit.message : null);
-    });
-});
+    })
+);
 
 // https://docs.github.com/ru/webhooks/webhook-events-and-payloads#workflow_run
-WebhookHandler.on('workflow_run', (anEv) => {
-    HandlerWrap(anEv, (ev) => {
+WebhookHandler.on('workflow_run', HandlerWrap((ev) => {
         const e = ev.payload.workflow_run;
         Logger.info("workflow_run event:", e.head_sha);
         // e.pull_requests is empty for the staged commit
@@ -89,12 +87,11 @@ WebhookHandler.on('workflow_run', (anEv) => {
         }
         const list = Array.from(e.pull_requests, v => v.number);
         return Util.PrId.PrNumList(list);
-    });
-});
+    })
+);
 
 // https://docs.github.com/en/webhooks/webhook-events-and-payloads#check_run
-WebhookHandler.on('check_run', (anEv) => {
-    HandlerWrap(anEv, (ev) => {
+WebhookHandler.on('check_run', HandlerWrap((ev) => {
         const e = ev.payload.check_run;
         Logger.info("check_run event:", e.head_sha);
         // e.check_suite.pull_requests is empty for the staged commit
@@ -108,8 +105,8 @@ WebhookHandler.on('check_run', (anEv) => {
         }
         const list = Array.from(e.check_suite.pull_requests, v => v.number);
         return Util.PrId.PrNumList(list);
-    });
-});
+    })
+);
 
 WebhookHandler.on('ping', (ev) => {
     const e = ev.payload;

--- a/src/Main.js
+++ b/src/Main.js
@@ -23,7 +23,7 @@ function HandlerWrap(ev, handler) {
     try {
         handler(ev);
     } catch (err) {
-        Logger.error("Error in ", err.message);
+        Logger.error("Error in", err.message);
         Merger.run(null);
     }
 }
@@ -105,7 +105,9 @@ WebhookHandler.on('workflow_run', (anEv) => {
         return;
     }
     if (!e.pull_requests.length) {
-        throw new Error("workflow_run event: pull_requests array is empty");
+        // e.pull_requests is empty, e.g., for master commits
+        Logger.info("workflow_run event: no PR for ", e.head_sha);
+        return;
     }
     const list = Array.from(e.pull_requests, v => v.number);
     Merger.run(Util.PrId.PrNumList(list));
@@ -123,7 +125,9 @@ WebhookHandler.on('check_run', (anEv) => {
         return;
     }
     if (!e.check_suite.pull_requests.length) {
-        throw new Error("check_run event: pull_requests array is empty");
+        // e.check_suite.pull_requests is empty, e.g., for master commits
+        Logger.info("check_run event: no PR for ", e.head_sha);
+        return;
     }
     const list = Array.from(e.check_suite.pull_requests, v => v.number);
     Merger.run(Util.PrId.PrNumList(list));

--- a/src/Main.js
+++ b/src/Main.js
@@ -80,6 +80,11 @@ WebhookHandler.on('push', (ev) => {
 WebhookHandler.on('workflow_run', (ev) => {
     const e = ev.payload.workflow_run;
     Logger.info("workflow_run event:", e.head_sha);
+    // e.pull_requests is empty for the staged commit
+    if (e.head_branch === Config.stagingBranch()) {
+        Merger.run([e.head_sha]);
+        return;
+    }
     if (!e.pull_requests.length) {
         Logger.warn("workflow_run event: pull_requests array is empty");
         Merger.run([null]);
@@ -92,6 +97,11 @@ WebhookHandler.on('workflow_run', (ev) => {
 WebhookHandler.on('check_run', (ev) => {
     const e = ev.payload.check_run;
     Logger.info("check_run event:", e.head_sha);
+    // e.check_suite.pull_requests is empty for the staged commit
+    if (e.check_suite.head_branch === Config.stagingBranch()) {
+        Merger.run([e.head_sha]);
+        return;
+    }
     if (!e.check_suite.pull_requests.length) {
         Logger.warn("check_run event: pull_requests array is empty");
         Merger.run([null]);

--- a/src/Main.js
+++ b/src/Main.js
@@ -26,10 +26,11 @@ function HandlerWrap(handler) {
         try {
             prIds = handler(ev);
             assert(prIds);
+            Logger.info("PrIds discovered by the event handler:", prIds.length);
             if (prIds.length === 0)
                 return;
         } catch (err) {
-            Logger.error("Error in", err.message);
+            Logger.error("Event handler error:", err.message);
         }
         Merger.run(prIds);
     };
@@ -37,78 +38,72 @@ function HandlerWrap(handler) {
 
 // https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent
 WebhookHandler.on('pull_request_review', HandlerWrap((ev) => {
-        const pr = ev.payload.pull_request;
-        Logger.info("pull_request_review event:", ev.payload.id, pr.number, pr.head.sha, pr.state);
-        return Util.PrId.PrNum(pr.number);
-    })
-);
+    const pr = ev.payload.pull_request;
+    Logger.info("pull_request_review event:", ev.payload.id, pr.number, pr.head.sha, pr.state);
+    return Util.PrId.PrNum(pr.number);
+}));
 
 // https://developer.github.com/v3/activity/events/types/#pullrequestevent
 WebhookHandler.on('pull_request', HandlerWrap((ev) => {
-        const pr = ev.payload.pull_request;
-        Logger.info("pull_request event:", ev.payload.id, pr.number, pr.head.sha, pr.state);
-        return Util.PrId.PrNum(pr.number);
-    })
-);
+    const pr = ev.payload.pull_request;
+    Logger.info("pull_request event:", ev.payload.id, pr.number, pr.head.sha, pr.state);
+    return Util.PrId.PrNum(pr.number);
+}));
 
 // https://developer.github.com/v3/activity/events/types/#statusevent
 WebhookHandler.on('status', HandlerWrap((ev) => {
-        const e = ev.payload;
-        Logger.info("status event:", e.id, e.sha, e.context, e.state);
-        const branches = Array.from(e.branches, b => b.name);
-        return Util.PrId.BranchList(branches, e.commit.commit.message);
-    })
-);
+    const e = ev.payload;
+    Logger.info("status event:", e.id, e.sha, e.context, e.state);
+    const branches = Array.from(e.branches, b => b.name);
+    return Util.PrId.BranchList(branches, e.commit.commit.message);
+}));
 
 // https://developer.github.com/v3/activity/events/types/#pushevent
 WebhookHandler.on('push', HandlerWrap((ev) => {
-        const e = ev.payload;
-        Logger.info("push event:", e.ref);
+    const e = ev.payload;
+    Logger.info("push event:", e.ref);
 
-        // e.ref as refs/heads/branch_name
-        const parts = e.ref.split('/');
-        const branch = parts[parts.length-1];
-        return Util.PrId.BranchList([branch], e.head_commit ? e.head_commit.message : null);
-    })
-);
+    // e.ref as refs/heads/branch_name
+    const parts = e.ref.split('/');
+    const branch = parts[parts.length-1];
+    return Util.PrId.BranchList([branch], e.head_commit ? e.head_commit.message : null);
+}));
 
 // https://docs.github.com/ru/webhooks/webhook-events-and-payloads#workflow_run
 WebhookHandler.on('workflow_run', HandlerWrap((ev) => {
-        const e = ev.payload.workflow_run;
-        Logger.info("workflow_run event:", e.head_sha);
-        // e.pull_requests is empty for the staged commit
-        if (e.head_branch === Config.stagingBranch()) {
-            assert(!e.pull_requests.length);
-            return Util.PrId.Sha(e.head_sha);
-        }
-        if (!e.pull_requests.length) {
-            // e.pull_requests is empty, e.g., for master commits
-            Logger.info("workflow_run event: no PR for ", e.head_sha);
-            return [];
-        }
+    const e = ev.payload.workflow_run;
+    Logger.info("workflow_run event:", e.head_sha);
+
+    if (e.pull_requests.length) {
         const list = Array.from(e.pull_requests, v => v.number);
         return Util.PrId.PrNumList(list);
-    })
-);
+    }
+
+    if (e.head_branch === Config.stagingBranch()) {
+        return Util.PrId.Sha(e.head_sha);
+    }
+    // workflow runs for other non-PR branches (e.g., master) are not associated with PRs
+    Logger.info("workflow_run event: no PR for", e.head_sha);
+    return [];
+}));
 
 // https://docs.github.com/en/webhooks/webhook-events-and-payloads#check_run
 WebhookHandler.on('check_run', HandlerWrap((ev) => {
-        const e = ev.payload.check_run;
-        Logger.info("check_run event:", e.head_sha);
-        // e.check_suite.pull_requests is empty for the staged commit
-        if (e.check_suite.head_branch === Config.stagingBranch()) {
-            assert(!e.check_suite.pull_requests.length);
-            return Util.PrId.Sha(e.head_sha);
-        }
-        if (!e.check_suite.pull_requests.length) {
-            // e.check_suite.pull_requests is empty, e.g., for master commits
-            Logger.info("check_run event: no PR for ", e.head_sha);
-            return [];
-        }
+    const e = ev.payload.check_run;
+    Logger.info("check_run event:", e.head_sha);
+
+    if (e.check_suite.pull_requests.length) {
         const list = Array.from(e.check_suite.pull_requests, v => v.number);
         return Util.PrId.PrNumList(list);
-    })
-);
+    }
+
+    if (e.check_suite.head_branch === Config.stagingBranch()) {
+        return Util.PrId.Sha(e.head_sha);
+    }
+    // check runs for other non-PR branches (e.g., master) are not associated with PRs
+    Logger.info("check_run event: no PR for", e.head_sha);
+    return [];
+}));
 
 WebhookHandler.on('ping', (ev) => {
     const e = ev.payload;

--- a/src/Main.js
+++ b/src/Main.js
@@ -60,20 +60,6 @@ WebhookHandler.on('check_run', (ev) => {
     Merger.run(null, "check_run", e);
 });
 
-// https://docs.github.com/ru/webhooks/webhook-events-and-payloads#workflow_run
-WebhookHandler.on('workflow_run', (ev) => {
-    const e = ev.payload.workflow_run;
-    Logger.info("workflow_run event:", e.head_sha);
-    Merger.run();
-});
-
-// https://docs.github.com/en/webhooks/webhook-events-and-payloads#check_run
-WebhookHandler.on('check_run', (ev) => {
-    const e = ev.payload.check_run;
-    Logger.info("check_run event:", e.head_sha);
-    Merger.run();
-});
-
 WebhookHandler.on('ping', (ev) => {
     const e = ev.payload;
     Logger.info("ping event, hook_id:", e.hook_id);

--- a/src/Main.js
+++ b/src/Main.js
@@ -53,7 +53,8 @@ WebhookHandler.on('push', (ev) => {
     Logger.info("push event:", e.ref);
 
     // e.ref as refs/heads/branch_name
-    const branch = e.ref.split('/')
+    const parts = e.ref.split('/')
+    const branch = parts[parts.length-1];
 
     if (branch !== Config.stagingBranch()) {
         Merger.run([branch]);

--- a/src/Main.js
+++ b/src/Main.js
@@ -46,6 +46,20 @@ WebhookHandler.on('push', (ev) => {
     Merger.run(null, "push", e);
 });
 
+// https://docs.github.com/ru/webhooks/webhook-events-and-payloads#workflow_run
+WebhookHandler.on('workflow_run', (ev) => {
+    const e = ev.payload.workflow_run;
+    Logger.info("workflow_run event:", e.head_sha);
+    Merger.run(null, "workflow_run", e);
+});
+
+// https://docs.github.com/en/webhooks/webhook-events-and-payloads#check_run
+WebhookHandler.on('check_run', (ev) => {
+    const e = ev.payload.check_run;
+    Logger.info("check_run event:", e.head_sha);
+    Merger.run(null, "check_run", e);
+});
+
 WebhookHandler.on('ping', (ev) => {
     const e = ev.payload;
     Logger.info("ping event, hook_id:", e.hook_id);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1267,9 +1267,18 @@ class PullRequest {
         return str + ")";
     }
 
+    _dateForDaysAgo(days) {
+        let d = new Date();
+        d.setDate(d.getDate() - days);
+        const dd = String(d.getDate()).padStart(2, '0');
+        const mm = String(d.getMonth() + 1).padStart(2, '0'); //January is 0!
+        const yyyy = d.getFullYear();
+        return yyyy + '-' + mm + '-' + dd;
+    }
+
     /// Checks whether the PR base branch has this PR's staged commit merged.
     async _mergedSomeTimeAgo() {
-        const dateSince = Util.DateForDaysAgo(100);
+        const dateSince = this._dateForDaysAgo(100);
         let mergedSha = null;
         let commits = await GH.getCommits(this._prBaseBranch(), dateSince);
         for (let commit of commits) {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1267,18 +1267,9 @@ class PullRequest {
         return str + ")";
     }
 
-    _dateForDaysAgo(days) {
-        let d = new Date();
-        d.setDate(d.getDate() - days);
-        const dd = String(d.getDate()).padStart(2, '0');
-        const mm = String(d.getMonth() + 1).padStart(2, '0'); //January is 0!
-        const yyyy = d.getFullYear();
-        return yyyy + '-' + mm + '-' + dd;
-    }
-
     /// Checks whether the PR base branch has this PR's staged commit merged.
     async _mergedSomeTimeAgo() {
-        const dateSince = this._dateForDaysAgo(100);
+        const dateSince = Util.DateForDaysAgo(100);
         let mergedSha = null;
         let commits = await GH.getCommits(this._prBaseBranch(), dateSince);
         for (let commit of commits) {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1054,7 +1054,7 @@ class PullRequest {
         const stagedSha = await GH.getReference(Config.stagingBranchPath());
         const stagedCommit = await GH.getCommit(stagedSha);
         const prNum = Util.ParsePrNumber(stagedCommit.message);
-        if (prNum !== null && this._prNumber().toString() === prNum) {
+        if (prNum !== null && this._prNumber() === prNum) {
             this._log("found staged commit " + stagedSha);
             this._stagedCommit = stagedCommit;
             return;
@@ -1288,7 +1288,7 @@ class PullRequest {
         let commits = await GH.getCommits(this._prBaseBranch(), dateSince);
         for (let commit of commits) {
             const num = Util.ParsePrNumber(commit.commit.message);
-            if (num && num === this._prNumber().toString()) {
+            if (num && num === this._prNumber()) {
                 assert(!mergedSha); // the PR can be merged only once
                 mergedSha = commit.sha;
             }

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -74,10 +74,6 @@ class PrMerger {
         this._total = this._todo.length;
         Logger.info(`Received ${this._total} PRs from GitHub:`, this._prNumbers());
 
-        let currentScan = new PrScanResult(this._todo);
-        if (this._todo.length === 0)
-            return currentScan;
-
         const currentPr = await this._current();
         await this._determineProcessingOrder(currentPr);
 
@@ -95,6 +91,7 @@ class PrMerger {
         }
 
         let somePrWasStaged = false;
+        let currentScan = new PrScanResult(this._todo);
         while (this._todo.length) {
             try {
                 const rawPr = this._todo.shift();

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -35,6 +35,11 @@ class PrScanResult {
         if (freshRawPr.labels.some(el => el.name === Config.clearedForMergeLabel()))
             return false;
 
+        // XXX: The above concern also applies to PRs that are not "cleared for
+        // merging" but can be proactively staged in anticipation of that
+        // clearance. TODO: Mark the first such PR that is waiting for the
+        // staging branch "lock" and treat it as "changed", returning false.
+
         const savedRawPr = this.awakePrs.find(el => el.number === freshRawPr.number);
         if (savedRawPr) {
             if (savedRawPr.updated_at !== freshRawPr.updated_at)

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -61,13 +61,16 @@ class PrMerger {
         this._total = this._todo.length;
         Logger.info(`Received ${this._total} PRs from GitHub:`, this._prNumbers());
         let updatedPrs = Array.from(prIds, (id) => {
-            // id is not SHA-1
-            if (id.length !== 40)
+            if (id === null) // an event handler could not extract id earlier
                 return id;
-            const pr = this._todo.find(p => p.head.sha === id);
+
+            if (typeof(id) === "number")
+                return id.toString();
+
+            const pr = this._todo.find(p => p.head.ref === id);
             if (pr)
                 return pr.number.toString();
-            Logger.warn(`could not find a PR by ${id} head sha`);
+            Logger.warn(`could not find a PR by ${id} branch`);
             return null;
         });
 

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -11,6 +11,7 @@ class PrScanResult {
         this.scanDate = new Date(); // the scan starting time
         this.awakePrs = [...prs]; // PRs that were not delayed during the scan
         this.minDelay = null; // if there are delayed PRs, pause them for at least this many milliseconds
+        this.delayedPrNum = null; // the PR that is delayed for minDelay or nill
     }
 
     isStillUnchanged(freshRawPr, freshScanDate) {
@@ -29,8 +30,10 @@ class PrScanResult {
         const oldPrs = this.awakePrs;
         this.awakePrs = this.awakePrs.filter(el => el.number !== rawPr.number);
         assert(oldPrs.length === this.awakePrs.length + 1); // one PR was removed
-        if (this.minDelay === null || this.minDelay > delay)
+        if (this.minDelay === null || this.minDelay > delay) {
             this.minDelay = delay;
+            this.delayedPrNum = rawPr.number;
+        }
     }
 }
 
@@ -234,7 +237,7 @@ async function Step(prIds) {
     _LastScan = null;
     const mergerer = new PrMerger();
     _LastScan = await mergerer.execute(lastScan, prIds);
-    return _LastScan.minDelay;
+    return {delay: _LastScan.minDelay, delayedPrNum: _LastScan.delayedPrNum};
 }
 
 module.exports = Step;

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -91,7 +91,7 @@ class PrMerger {
                 }
 
                 // The 'lastScan' check turns off optimization for the initial scan.
-                if (updatedPrs && !updatedPrs.some(el => el === rawPr.number) && lastScan && lastScan.isStillUnchanged(rawPr, currentScan.scanDate)) {
+                if (updatedPrs && !updatedPrs.some(el => el === rawPr.number.toString()) && lastScan && lastScan.isStillUnchanged(rawPr, currentScan.scanDate)) {
                     const updatedAt = new Date(rawPr.updated_at);
                     Logger.info(`Ignoring PR${rawPr.number} because it has not changed since ${updatedAt.toISOString()}`);
                     this._ignoredAsUnchanged++;
@@ -173,7 +173,7 @@ class PrMerger {
 
         for (let id of prIds) {
             if (id.type === "prNum") {
-                prNumList.push(id.value);
+                prNumList.push(id.value.toString());
             } else if (id.type === "sha") {
                 if (currentPr && (id.value === this._stagedBranchSha)) {
                     prNumList.push(currentPr.number.toString());
@@ -194,8 +194,8 @@ class PrMerger {
                 if (pr) {
                     prNumList.push(pr.number.toString());
                 } else {
-                    Logger.warn(`Could not find a PR by ${id} branch`);
-                    return null;
+                    Logger.info(`Could not find a PR by ${id} branch`);
+                    continue;
                 }
             }
         }

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -68,7 +68,7 @@ class PrMerger {
         // Treat the 'null' updatedPrs below as if all PRs have been 'updated'.
         // An empty updatedPrs means that none of the PRs has been updated.
         if (updatedPrs === null) {
-            Logger.warn('discarding PR scan optimization');
+            Logger.info('will not use PR scan optimization');
         } else {
             // remove duplicates
             updatedPrs = updatedPrs.filter((v, idx) => updatedPrs.indexOf(v) === idx);

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -65,7 +65,7 @@ class PrMerger {
         const currentPr = await this._current();
         await this._determineProcessingOrder(currentPr);
 
-        let updatedPrs = await this._extractPrNumbers(prIds, currentPr);
+        let updatedPrs = await this._prNumbersFromShas(prIds, currentPr);
 
         updatedPrs = Array.from(updatedPrs, (id) => {
             if (id === null) // an event handler could not extract id earlier
@@ -180,7 +180,7 @@ class PrMerger {
         Logger.info("PR processing order:", this._prNumbers());
     }
 
-    async _extractPrNumbers(prIdsIn, currentPr) {
+    async _prNumbersFromShas(prIdsIn, currentPr) {
         let prIdsOut = [];
 
         for (let id of prIdsIn) {

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -10,7 +10,7 @@ class PrScanResult {
     constructor(prs) {
         this.scanDate = new Date(); // the scan starting time
         this.awakePrs = [...prs]; // PRs that were not delayed during the scan
-        this.delayedPrs = []; // PRs that have been delayed
+        this.delayedPrs = []; // PRs that were delayed during the scan (an array of {prNumber, expirationDate} pairs)
         this.minDelay = null; // if there are delayed PRs, pause them for at least this many milliseconds
     }
 
@@ -103,7 +103,8 @@ class PrMerger {
                 updatedPrs.push(currentPr.number.toString());
             // remove duplicates
             updatedPrs = updatedPrs.filter((v, idx) => updatedPrs.indexOf(v) === idx);
-            Logger.info('recently updated PRs: [' + updatedPrs.join() + ']');
+            const prNumbers = updatedPrs.join();
+            Logger.info(`Got events since ${lastScan.scanDate.toISOString()}for these PRs: [${prNumbers}]`);
         }
 
         let somePrWasStaged = false;

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -104,7 +104,7 @@ class PrMerger {
             // remove duplicates
             updatedPrs = updatedPrs.filter((v, idx) => updatedPrs.indexOf(v) === idx);
             const prNumbers = updatedPrs.join();
-            Logger.info(`Got events since ${lastScan.scanDate.toISOString()}for these PRs: [${prNumbers}]`);
+            Logger.info(`Got events since ${lastScan.scanDate.toISOString()} for these PRs: [${prNumbers}]`);
         }
 
         let somePrWasStaged = false;

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -166,10 +166,12 @@ class PrMerger {
         Logger.info("PR processing order:", this._prNumbers());
     }
 
-    async _prNumbersFromIds(prIdsIn, currentPr, prList) {
+    // Translates each element of prIds into a PR number.
+    // Returns an array of PR numbers if it could translate all Ids or null otherwise.
+    async _prNumbersFromIds(prIds, currentPr, prList) {
         let prNumList = [];
 
-        for (let id of prIdsIn) {
+        for (let id of prIds) {
             if (id.type === "prNum") {
                 prNumList.push(id.value);
             } else if (id.type === "sha") {

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -34,99 +34,6 @@ class PrScanResult {
     }
 }
 
-// accumulates GitHub events received during a PR scan
-// and extracts PR numbers from them
-class Events {
-    constructor() {
-        this._pullRequests = [];
-        this._pullRequestReviews = [];
-        this._pushes = [];
-        this._statuses = [];
-        this._checkRuns = [];
-        this._workflowRuns = [];
-    }
-
-    add(name, ev) {
-        Logger.info("Events.add: " + name);
-        if (name === "pull_request")
-            this._pullRequests.push(ev);
-        else if (name === "pull_request_review")
-            this._pullRequestReviews.push(ev);
-        else if (name === "push")
-            this._pushes.push(ev);
-        else if (name === "status")
-            this._statuses.push(ev);
-        else if (name === "check_run")
-            this._checkRuns.push(ev);
-        else if (name === "workflow_run")
-            this._workflowRuns.push(ev);
-    }
-
-    // returns an array of PR numbers extracted from the events
-    updatedPrs(allPrs) {
-        let prs = [];
-        for (let e of this._pullRequests)
-            prs.push(e.number.toString());
-        for (let e of this._pullRequestReviews)
-            prs.push(e.number.toString());
-        for (let e of this._pushes) {
-            const prNum = this._prFromPush(allPrs, e);
-            if (prNum)
-                prs.push(prNum.toString());
-        }
-        for (let e of this._statuses) {
-            const prNum = this._prFromStatus(allPrs, e);
-            if (prNum)
-                prs.push(prNum.toString());
-        }
-        for (let e of this._checkRuns) {
-            for (let pr of e.check_suite.pull_requests)
-                prs.push(pr.number);
-        }
-        for (let e of this._workflowRuns) {
-            for (let pr of e.pull_requests)
-                prs.push(pr.number);
-        }
-
-        // remove duplicates
-        prs = prs.filter((v, idx) => prs.indexOf(v) === idx);
-        Logger.info('updated PRs: [' + prs.join() + ']');
-        return prs;
-    }
-
-    _prFromPush(prList, e) {
-        let prNum = null;
-        if (e.ref.endsWith(Config.stagingBranchPath())) {
-            if (e.head_commit)
-                prNum = Util.ParsePrNumber(e.head_commit.message);
-        } else {
-            for (let pr of prList) {
-                // may get SHA from e.after instead
-                if (pr.head.sha === e.head_commit.id)
-                    prNum = pr.number;
-            }
-        }
-        if (prNum === null)
-            Logger.info(`Could not extract PR number from push event SHA=${e.after}`);
-        return prNum;
-    }
-
-    _prFromStatus(prList, e) {
-        let prNum = null;
-        if (e.branches.some(b => b.name.endsWith(Config.stagingBranch()))) {
-            prNum = Util.ParsePrNumber(e.commit.commit.message);
-        } else {
-            for (let pr of prList) {
-                if (pr.head.sha === e.sha)
-                    prNum = pr.number;
-            }
-        }
-        if (prNum === null)
-            Logger.info(`Could not extract PR number from status event SHA=${e.sha}`);
-        return prNum;
-    }
-}
-
 // PrScanResult produced by the last successfully finished PrMerger.execute() call
 let _LastScan = null;
 
@@ -146,13 +53,27 @@ class PrMerger {
 
     // Implements a single Anubis processing step.
     // Returns suggested wait time until the next step (in milliseconds).
-    async execute(lastScan, events) {
+    async execute(lastScan, prIds) {
         Logger.info("runStep running");
 
         this._todo = await GH.getOpenPrs();
         this._total = this._todo.length;
         Logger.info(`Received ${this._total} PRs from GitHub:`, this._prNumbers());
-        const updatedPrs = events.updatedPrs(this._todo);
+        let updatedPrs = Array.from(prIds, (id) => {
+            // id is not SHA-1
+            if (id.length !== 40)
+                return id;
+            const pr = this._todo.find(pr => pr.head.sha === id);
+            if (pr)
+                return pr;
+            Logger.warn(`could not find a PR by ${id} head sha`);
+            return null;
+        });
+
+        if (updatedPrs.some(el => el === null)) {
+            Logger.warn('discarding PR scan optimization');
+            updatedPrs = null;
+        }
 
         await this._determineProcessingOrder(await this._current());
 
@@ -169,7 +90,7 @@ class PrMerger {
                 }
 
                 const clearedForMerge = rawPr.labels.some(el => el.name === Config.clearedForMergeLabel());
-                const updated = updatedPrs.some(el => el === rawPr.number);
+                const updated = !updatedPrs || updatedPrs.some(el => el === rawPr.number);
 
                 // If a PR A was cleared for merge, it may be ready for merge (no updates are expected)
                 // but waiting for another PR B which is currently being merged. If we switched back to PR A
@@ -269,16 +190,13 @@ class PrMerger {
 } // PrMerger
 
 // promises to process all PRs once, hiding PrMerger from callers
-async function Step(events) {
+async function Step(prIds) {
     const lastScan = _LastScan;
     _LastScan = null;
     const mergerer = new PrMerger();
-    _LastScan = await mergerer.execute(lastScan, events);
+    _LastScan = await mergerer.execute(lastScan, prIds);
     return _LastScan.minDelay;
 }
 
-module.exports = {
-    Step: Step,
-    Events: Events
-};
+module.exports = Step;
 

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -19,7 +19,8 @@ class PrScanResult {
     }
 
     isStillUnchanged(updatedPrs, freshRawPr, freshScanDate) {
-        if (!updatedPrs)
+        assert.strictEqual(arguments.length, 3);
+        if (updatedPrs === null)
             return false;
 
         if (updatedPrs.some(el => el === freshRawPr.number.toString()))
@@ -41,10 +42,9 @@ class PrScanResult {
         } else {
             const delayedPr = this.delayedPrs.find(el => el.number === freshRawPr.number);
             if (!delayedPr)
-                return false; // this scan has not seen freshRawPR (neither awakePrs no delayedPrs have it)
+                return false; // this scan has not seen freshRawPr (neither awakePrs nor delayedPrs have it)
 
-            let now = new Date();
-            if (delayedPr.expirationDate <= now)
+            if (delayedPr.expirationDate <= freshScanDate)
                 return false;
         }
 
@@ -219,6 +219,7 @@ class PrMerger {
             if (id.type === "prNum") {
                 prNumList.push(id.value.toString());
             } else if (id.type === "sha") {
+                assert(!currentPr || this._stagedBranchSha !== null);
                 if (currentPr && (id.value === this._stagedBranchSha)) {
                     prNumList.push(currentPr.number.toString());
                 } else {

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -71,10 +71,10 @@ class PrMerger {
             if (id === null) // an event handler could not extract id earlier
                 return id;
 
-            if (typeof(id) === "number")
+            if (typeof(id) === "number") // PR number
                 return id.toString();
 
-            const pr = this._todo.find(p => p.head.ref === id);
+            const pr = this._todo.find(p => p.head.ref === id); // PR branch
             if (pr)
                 return pr.number.toString();
             Logger.warn(`could not find a PR by ${id} branch`);
@@ -184,11 +184,12 @@ class PrMerger {
         let prIdsOut = [];
 
         for (let id of prIdsIn) {
+            // GitHub restricts 40-length strings for SHAs:
+            // https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names
             if (id.length !== 40) {
                 prIdsOut.push(id);
                 continue;
             }
-            // staged sha
             if (currentPr && (id === this._stagedBranchSha)) {
                 prIdsOut.push(currentPr.number);
                 continue;

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -61,6 +61,10 @@ class PrMerger {
         this._total = this._todo.length;
         Logger.info(`Received ${this._total} PRs from GitHub:`, this._prNumbers());
 
+        let currentScan = new PrScanResult(this._todo);
+        if (this._todo.length === 0)
+            return currentScan;
+
         const currentPr = await this._current();
         await this._determineProcessingOrder(currentPr);
 
@@ -76,7 +80,6 @@ class PrMerger {
         }
 
         let somePrWasStaged = false;
-        let currentScan = new PrScanResult(this._todo);
         while (this._todo.length) {
             try {
                 const rawPr = this._todo.shift();

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -77,6 +77,8 @@ class PrMerger {
         if (updatedPrs === null) {
             Logger.info('will not use PR scan optimization');
         } else {
+            if (currentPr)
+                updatedPrs.push(currentPr.number.toString());
             // remove duplicates
             updatedPrs = updatedPrs.filter((v, idx) => updatedPrs.indexOf(v) === idx);
             Logger.info('recently updated PRs: [' + updatedPrs.join() + ']');

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -87,10 +87,8 @@ class PrMerger {
                     continue;
                 }
 
-                const updated = !updatedPrs || updatedPrs.some(el => el === rawPr.number);
-
                 // The 'lastScan' check turns off optimization for the initial scan.
-                if (!updated && lastScan && lastScan.isStillUnchanged(rawPr, currentScan.scanDate)) {
+                if (updatedPrs && !updatedPrs.some(el => el === rawPr.number) && lastScan && lastScan.isStillUnchanged(rawPr, currentScan.scanDate)) {
                     const updatedAt = new Date(rawPr.updated_at);
                     Logger.info(`Ignoring PR${rawPr.number} because it has not changed since ${updatedAt.toISOString()}`);
                     this._ignoredAsUnchanged++;
@@ -164,6 +162,7 @@ class PrMerger {
     // Translates each element of prIds into a PR number.
     // Returns an array of PR numbers if it could translate all Ids or null otherwise.
     async _prNumbersFromIds(prIds, currentPr, prList) {
+        assert(prIds !== undefined);
         if (prIds === null)
             return null;
 
@@ -225,6 +224,9 @@ class PrMerger {
 
 // promises to process all PRs once, hiding PrMerger from callers
 async function Step(prIds) {
+    assert(prIds !== undefined);
+    if (prIds !== null)
+        Logger.info('prIds: [' + prIds.join() + ']');
     const lastScan = _LastScan;
     _LastScan = null;
     const mergerer = new PrMerger();

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -55,6 +55,7 @@ class PrMerger {
     // Returns suggested wait time until the next step (in milliseconds).
     async execute(lastScan, prIds) {
         Logger.info("runStep running");
+        Logger.info('prIds: [' + prIds.join() + ']');
 
         this._todo = await GH.getOpenPrs();
         this._total = this._todo.length;
@@ -63,16 +64,21 @@ class PrMerger {
             // id is not SHA-1
             if (id.length !== 40)
                 return id;
-            const pr = this._todo.find(pr => pr.head.sha === id);
+            const pr = this._todo.find(p => p.head.sha === id);
             if (pr)
-                return pr;
+                return pr.number.toString();
             Logger.warn(`could not find a PR by ${id} head sha`);
             return null;
         });
 
+        // remove duplicates
+        updatedPrs = updatedPrs.filter((v, idx) => updatedPrs.indexOf(v) === idx);
+
         if (updatedPrs.some(el => el === null)) {
             Logger.warn('discarding PR scan optimization');
             updatedPrs = null;
+        } else {
+            Logger.info('recently updated PRs: [' + updatedPrs.join() + ']');
         }
 
         await this._determineProcessingOrder(await this._current());

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -168,9 +168,13 @@ class PrMerger {
                     continue;
                 }
 
+                const clearedForMerge = rawPr.labels.some(el => el.name === Config.clearedForMergeLabel());
                 const updated = updatedPrs.some(el => el === rawPr.number);
 
-                if (!updated && lastScan && lastScan.isStillUnchanged(rawPr, currentScan.scanDate)) {
+                // If a PR A was cleared for merge, it may be ready for merge (no updates are expected)
+                // but waiting for another PR B which is currently being merged. If we switched back to PR A
+                // it may remain still ready for merge so we need to process it anyway.
+                if (!clearedForMerge && !updated && lastScan && lastScan.isStillUnchanged(rawPr, currentScan.scanDate)) {
                     const updatedAt = new Date(rawPr.updated_at);
                     Logger.info(`Ignoring PR${rawPr.number} because it has not changed since ${updatedAt.toISOString()}`);
                     this._ignoredAsUnchanged++;

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -10,7 +10,11 @@ class PrScanResult {
     constructor(prs) {
         this.scanDate = new Date(); // the scan starting time
         this.awakePrs = [...prs]; // PRs that were not delayed during the scan
-        this.delayedPrs = []; // PRs that were delayed during the scan (an array of {prNumber, expirationDate} pairs)
+        // PRs that wait for some timeout to expire.
+        // Each array element is an {number, expirationDate} structure,
+        // where the number field represents PR number of Number type and
+        // expirationDate member has a Date type
+        this.delayedPrs = [];
         this.minDelay = null; // if there are delayed PRs, pause them for at least this many milliseconds
     }
 
@@ -40,7 +44,7 @@ class PrScanResult {
                 return false; // this scan has not seen freshRawPR (neither awakePrs no delayedPrs have it)
 
             let now = new Date();
-            if (delayedPr.expireDate <= now)
+            if (delayedPr.expirationDate <= now)
                 return false;
         }
 
@@ -57,7 +61,7 @@ class PrScanResult {
         assert(!this.delayedPrs.some(el => el.number === rawPr.number));
         let date = new Date();
         date.setSeconds(date.getSeconds() + delay/1000);
-        this.delayedPrs.push({number: rawPr.number, expireDate: date});
+        this.delayedPrs.push({number: rawPr.number, expirationDate: date});
         if (this.minDelay === null || this.minDelay > delay)
             this.minDelay = delay;
     }

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -87,14 +87,10 @@ class PrMerger {
                     continue;
                 }
 
-                const clearedForMerge = rawPr.labels.some(el => el.name === Config.clearedForMergeLabel());
                 const updated = !updatedPrs || updatedPrs.some(el => el === rawPr.number);
 
-                // If a PR A was cleared for merge, it may be ready for merge (no updates are expected)
-                // but waiting for another PR B which is currently being merged. If we switched back to PR A
-                // it may remain still ready for merge so we need to process it anyway.
                 // The 'lastScan' check turns off optimization for the initial scan.
-                if (!clearedForMerge && !updated && lastScan && lastScan.isStillUnchanged(rawPr, currentScan.scanDate)) {
+                if (!updated && lastScan && lastScan.isStillUnchanged(rawPr, currentScan.scanDate)) {
                     const updatedAt = new Date(rawPr.updated_at);
                     Logger.info(`Ignoring PR${rawPr.number} because it has not changed since ${updatedAt.toISOString()}`);
                     this._ignoredAsUnchanged++;

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -23,7 +23,7 @@ class PrScanResult {
         if (updatedPrs === null)
             return false;
 
-        if (updatedPrs.some(el => el === freshRawPr.number.toString()))
+        if (updatedPrs.some(el => el === freshRawPr.number))
             return false;
 
         // A cleared for merging PR B may be waiting for PR A being merged. When
@@ -109,7 +109,7 @@ class PrMerger {
             Logger.info('will not use PR scan optimization');
         } else {
             if (currentPr)
-                updatedPrs.push(currentPr.number.toString());
+                updatedPrs.push(currentPr.number);
             // remove duplicates
             updatedPrs = updatedPrs.filter((v, idx) => updatedPrs.indexOf(v) === idx);
             const prNumbers = updatedPrs.join();
@@ -222,11 +222,11 @@ class PrMerger {
 
         for (let id of prIds) {
             if (id.type === "prNum") {
-                prNumList.push(id.value.toString());
+                prNumList.push(id.value);
             } else if (id.type === "sha") {
                 assert(!currentPr || this._stagedBranchSha !== null);
                 if (currentPr && (id.value === this._stagedBranchSha)) {
-                    prNumList.push(currentPr.number.toString());
+                    prNumList.push(currentPr.number);
                 } else {
                     const commit = await GH.getCommit(id.value);
                     const prNum = this._extractPrNumber(commit.message, id.value);
@@ -248,7 +248,7 @@ class PrMerger {
                         Logger.info(`Could not find a PR by ${id} branch`);
                         continue;
                     }
-                    prNumList.push(pr.number.toString());
+                    prNumList.push(pr.number);
                 }
             }
         }

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -49,6 +49,8 @@ class PrMerger {
         this._ignored = 0; // the number of PRs skipped due to human markings; TODO: Rename to _ignoredAsMarked
         this._ignoredAsUnchanged = 0; // the number of PRs skipped due to lack of PR updates
         this._todo = null; // raw PRs to be processed
+        // an array of {sha, prNum} pairs extracted from the staging branch history (for the last 30 days)
+        this._stagingBranchCommits = [];
     }
 
     // Implements a single Anubis processing step.
@@ -60,22 +62,33 @@ class PrMerger {
         this._todo = await GH.getOpenPrs();
         this._total = this._todo.length;
         Logger.info(`Received ${this._total} PRs from GitHub:`, this._prNumbers());
+
+        await this._getStagingBranchCommits();
+
         let updatedPrs = Array.from(prIds, (id) => {
-            if (id === null) // an event handler could not extract id earlier
+            if (id === null) // an event handler could not extract id
                 return id;
 
-            if (typeof(id) === "number")
+            if (typeof(id) === "number") // PR number
                 return id.toString();
 
-            const pr = this._todo.find(p => p.head.ref === id);
-            if (pr)
-                return pr.number.toString();
-            Logger.warn(`could not find a PR by ${id} branch`);
+            if (id.length === 40) { // staged sha
+                const commit = this._stagingBranchCommits.find(e => e.sha === id);
+                if (commit)
+                    return commit.prNum;
+            } else { // PR branch
+                const pr = this._todo.find(p => p.head.ref === id);
+                if (pr)
+                    return pr.number.toString();
+            }
+            Logger.warn(`could not find a PR by ${id}`);
             return null;
         });
 
         // remove duplicates
         updatedPrs = updatedPrs.filter((v, idx) => updatedPrs.indexOf(v) === idx);
+
+        await this._determineProcessingOrder(await this._current());
 
         if (updatedPrs.some(el => el === null)) {
             Logger.warn('discarding PR scan optimization');
@@ -83,8 +96,6 @@ class PrMerger {
         } else {
             Logger.info('recently updated PRs: [' + updatedPrs.join() + ']');
         }
-
-        await this._determineProcessingOrder(await this._current());
 
         let somePrWasStaged = false;
         let currentScan = new PrScanResult(this._todo);
@@ -175,17 +186,37 @@ class PrMerger {
         Logger.info("PR processing order:", this._prNumbers());
     }
 
+    async _getStagingBranchCommits() {
+        this._stagingBranchCommits = [];
+        const stagedCommits = await GH.getCommits(Config.stagingBranchPath(), Util.DateForDaysAgo(30));
+        if (stagedCommits.length) {
+            for (let commit of stagedCommits) {
+                const prNum = Util.ParsePrNumber(commit.commit.message);
+                if (prNum === null)
+                    Logger.warn(`Could not parse PR number for a staging ${commit.sha}`);
+                else
+                    this._stagingBranchCommits.push({sha: commit.sha, prNum: prNum});
+            }
+        } else {
+            const stagedBranchSha = await GH.getReference(Config.stagingBranchPath());
+            const stagedHeadCommit = await GH.getCommit(stagedBranchSha);
+            const prNum = Util.ParsePrNumber(stagedHeadCommit.message);
+            if (prNum === null)
+                Logger.warn(`Could not parse PR number for a head staging ${stagedHeadCommit.sha}`);
+            else
+                this._stagingBranchCommits.push({sha: stagedHeadCommit.sha, prNum: prNum});
+        }
+    }
+
     // Returns a raw PR with a staged commit (or null).
     // If that PR exists, it is in either a "staged" or "merged" state.
     async _current() {
         Logger.info("Looking for the current PR...");
-        const stagedBranchSha = await GH.getReference(Config.stagingBranchPath());
-        const stagedBranchCommit = await GH.getCommit(stagedBranchSha);
-        Logger.info("Staged branch head sha: " + stagedBranchCommit.sha);
-        const prNum = Util.ParsePrNumber(stagedBranchCommit.message);
-        if (prNum === null) {
+        if (!this._stagingBranchCommits.length) {
             Logger.info("Could not track a PR by the staged branch.");
         } else {
+            Logger.info("Staged branch head sha: " + this._stagingBranchCommits[0].sha);
+            const prNum = this._stagingBranchCommits[0].prNum;
             const pr = await GH.getPR(prNum, false);
             if (pr.state === 'open') {
                 Logger.info("PR" + prNum + " is the current");

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -14,7 +14,13 @@ class PrScanResult {
         this.delayedPrNum = null; // the PR that is delayed for minDelay or nill
     }
 
-    isStillUnchanged(freshRawPr, freshScanDate) {
+    isStillUnchanged(updatedPrs, freshRawPr, freshScanDate) {
+        if (!updatedPrs)
+            return false;
+
+        if (updatedPrs.some(el => el === freshRawPr.number.toString()))
+            return false;
+
         // A cleared for merging PR B may be waiting for PR A being merged. When
         // PR A is merged or its merging fails, we may need to advance PR B, even
         // though PR B remains unchanged from GitHub metadata/events point of view.
@@ -103,7 +109,7 @@ class PrMerger {
                 }
 
                 // The 'lastScan' check turns off optimization for the initial scan.
-                if (updatedPrs && !updatedPrs.some(el => el === rawPr.number.toString()) && lastScan && lastScan.isStillUnchanged(rawPr, currentScan.scanDate)) {
+                if (lastScan && lastScan.isStillUnchanged(updatedPrs, rawPr, currentScan.scanDate)) {
                     const updatedAt = new Date(rawPr.updated_at);
                     Logger.info(`Ignoring PR${rawPr.number} because it has not changed since ${updatedAt.toISOString()}`);
                     this._ignoredAsUnchanged++;

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -62,6 +62,7 @@ class PrScanResult {
         const oldPrs = this.awakePrs;
         this.awakePrs = this.awakePrs.filter(el => el.number !== rawPr.number);
         assert(oldPrs.length === this.awakePrs.length + 1); // one PR was removed
+
         assert(!this.delayedPrs.some(el => el.number === rawPr.number));
         let date = new Date();
         date.setSeconds(date.getSeconds() + delay/1000);

--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -48,7 +48,6 @@ class PrScanResult {
             const delayedPr = this.delayedPrs.find(el => el.number === freshRawPr.number);
             if (!delayedPr)
                 return false; // this scan has not seen freshRawPr (neither awakePrs nor delayedPrs have it)
-
             if (delayedPr.expirationDate <= freshScanDate)
                 return false;
         }

--- a/src/RepoMerger.js
+++ b/src/RepoMerger.js
@@ -47,7 +47,8 @@ class RepoMerger {
         });
     }
 
-    // prNum (if provided) corresponds to a PR, scheduled this 'run'
+    // evName (event name) and ev (event data), if provided, correspond to an event
+    // that scheduled this 'run'
     async run(handler, evName, ev) {
         if (handler)
             this._handler = handler;

--- a/src/RepoMerger.js
+++ b/src/RepoMerger.js
@@ -47,7 +47,10 @@ class RepoMerger {
         });
     }
 
-    // prIds (if provided) an array of strings, each represents either PR number or PR head SHA.
+    // prIds (if provided) an array of elements, each represents:
+    // a PR number as an integer, or
+    // a PR branch name as a string (without 'refs' or 'heads' prefixes), or
+    // a staging branch commit SHA as a string (including stale commits).
     async run(prIds, handler) {
         if (handler)
             this._handler = handler;

--- a/src/RepoMerger.js
+++ b/src/RepoMerger.js
@@ -50,15 +50,14 @@ class RepoMerger {
     // prIds is an array of Util.PrId objects collected by event handlers (or null)
     async run(prIds, handler) {
         assert(prIds !== undefined);
-
-        if (handler)
-            this._handler = handler;
-
         if (prIds === null)
             this._prIds = null;
         else if (this._prIds !== null)
             this._prIds.push(...prIds);
         // else keep discarding prIds until this._prIds is reset below
+
+        if (handler)
+            this._handler = handler;
 
         if (this._running) {
             Logger.info("Already running, planning rerun.");

--- a/src/RepoMerger.js
+++ b/src/RepoMerger.js
@@ -67,7 +67,7 @@ class RepoMerger {
         }
         this._unplan();
         this._running = true;
-        let rerunInfo = null;
+        let rerunIn = null;
         do {
             try {
                 this._rerun = false;
@@ -75,7 +75,7 @@ class RepoMerger {
                 this._prIds = [];
                 if (!this._server)
                     await this._createServer();
-                rerunInfo = await Step(ids);
+                rerunIn = await Step(ids);
             } catch (e) {
                 Log.LogError(e, "RepoMerger.run");
                 this._rerun = true;
@@ -87,8 +87,8 @@ class RepoMerger {
                 await Util.sleep(period * 60 * 1000); // 10 min
             }
         } while (this._rerun);
-        if (rerunInfo.delay)
-            this._plan(rerunInfo.delay, rerunInfo.delayedPrNum);
+        if (rerunIn)
+            this._plan(rerunIn);
         this._running = false;
     }
 
@@ -97,7 +97,7 @@ class RepoMerger {
         this._server = null;
     }
 
-    _plan(requestedMs, prNum) {
+    _plan(requestedMs) {
         assert(requestedMs > 0);
         // obey node.js setTimeout() limits
         const maxMs = Math.pow(2, 31) - 1;
@@ -106,7 +106,7 @@ class RepoMerger {
         assert(this._timer === null);
         let date = new Date();
         date.setSeconds(date.getSeconds() + ms/1000);
-        this._timer = setTimeout(this.run.bind(this, Util.PrId.PrNum(prNum)), ms);
+        this._timer = setTimeout(this.run.bind(this, []), ms);
         Logger.info("planning rerun in " + this._msToTime(ms));
     }
 

--- a/src/RepoMerger.js
+++ b/src/RepoMerger.js
@@ -67,7 +67,7 @@ class RepoMerger {
         }
         this._unplan();
         this._running = true;
-        let rerunIn = null;
+        let rerunInfo = null;
         do {
             try {
                 this._rerun = false;
@@ -75,7 +75,7 @@ class RepoMerger {
                 this._prIds = [];
                 if (!this._server)
                     await this._createServer();
-                rerunIn = await Step(ids);
+                rerunInfo = await Step(ids);
             } catch (e) {
                 Log.LogError(e, "RepoMerger.run");
                 this._rerun = true;
@@ -87,8 +87,8 @@ class RepoMerger {
                 await Util.sleep(period * 60 * 1000); // 10 min
             }
         } while (this._rerun);
-        if (rerunIn)
-            this._plan(rerunIn);
+        if (rerunInfo.delay)
+            this._plan(rerunInfo.delay, rerunInfo.delayedPrNum);
         this._running = false;
     }
 
@@ -97,7 +97,7 @@ class RepoMerger {
         this._server = null;
     }
 
-    _plan(requestedMs) {
+    _plan(requestedMs, prNum) {
         assert(requestedMs > 0);
         // obey node.js setTimeout() limits
         const maxMs = Math.pow(2, 31) - 1;
@@ -106,7 +106,7 @@ class RepoMerger {
         assert(this._timer === null);
         let date = new Date();
         date.setSeconds(date.getSeconds() + ms/1000);
-        this._timer = setTimeout(this.run.bind(this), ms);
+        this._timer = setTimeout(this.run.bind(this, Util.PrId.PrNum(prNum)), ms);
         Logger.info("planning rerun in " + this._msToTime(ms));
     }
 

--- a/src/RepoMerger.js
+++ b/src/RepoMerger.js
@@ -16,7 +16,7 @@ class RepoMerger {
         this._running = false;
         this._handler = null;
         this._server = null;
-        this._prIds = [];
+        this._prIds = null;
     }
 
     _createServer() {
@@ -49,10 +49,14 @@ class RepoMerger {
 
     // prIds (if provided) an array of Util.PrId elements filled by an event
     async run(prIds, handler) {
+        assert(prIds !== undefined);
+
         if (handler)
             this._handler = handler;
 
-        if (prIds)
+        if (prIds === null)
+            this._prIds = null;
+        else
             this._prIds.push(...prIds);
 
         if (this._running) {
@@ -70,6 +74,8 @@ class RepoMerger {
                     await this._createServer();
                 const ids = this._prIds;
                 this._prIds = [];
+                if (ids !== null)
+                    Logger.info('prIds: [' + ids.join() + ']');
                 rerunIn = await Step(ids);
             } catch (e) {
                 Log.LogError(e, "RepoMerger.run");

--- a/src/RepoMerger.js
+++ b/src/RepoMerger.js
@@ -56,8 +56,9 @@ class RepoMerger {
 
         if (prIds === null)
             this._prIds = null;
-        else
+        else if (this._prIds !== null)
             this._prIds.push(...prIds);
+        // else keep discarding prIds until next rerun (prIds !== null && this._prIds === null)
 
         if (this._running) {
             Logger.info("Already running, planning rerun.");
@@ -70,12 +71,10 @@ class RepoMerger {
         do {
             try {
                 this._rerun = false;
-                if (!this._server)
-                    await this._createServer();
                 const ids = this._prIds;
                 this._prIds = [];
-                if (ids !== null)
-                    Logger.info('prIds: [' + ids.join() + ']');
+                if (!this._server)
+                    await this._createServer();
                 rerunIn = await Step(ids);
             } catch (e) {
                 Log.LogError(e, "RepoMerger.run");

--- a/src/RepoMerger.js
+++ b/src/RepoMerger.js
@@ -3,7 +3,7 @@ const http = require('http');
 const Config = require('./Config.js');
 const Log = require('./Logger.js');
 const Util = require('./Util.js');
-const PrMerger = require('./PrMerger.js');
+const Step = require('./PrMerger.js');
 
 const Logger = Log.Logger;
 
@@ -16,7 +16,7 @@ class RepoMerger {
         this._running = false;
         this._handler = null;
         this._server = null;
-        this._events = new PrMerger.Events();
+        this._prIds = [];
     }
 
     _createServer() {
@@ -47,13 +47,13 @@ class RepoMerger {
         });
     }
 
-    // evName (event name) and ev (event data), if provided, correspond to an event
-    // that scheduled this 'run'
-    async run(handler, evName, ev) {
+    // prIds (if provided) an array of strings, each represents either PR number or PR head SHA.
+    async run(prIds, handler) {
         if (handler)
             this._handler = handler;
 
-        this._events.add(evName, ev);
+        if (prIds)
+            this._prIds.push(...prIds);
 
         if (this._running) {
             Logger.info("Already running, planning rerun.");
@@ -68,9 +68,9 @@ class RepoMerger {
                 this._rerun = false;
                 if (!this._server)
                     await this._createServer();
-                let events = this._events;
-                this._events = new PrMerger.Events();
-                rerunIn = await PrMerger.Step(events);
+                const ids = this._prIds;
+                this._prIds = [];
+                rerunIn = await Step(ids);
             } catch (e) {
                 Log.LogError(e, "RepoMerger.run");
                 this._rerun = true;

--- a/src/RepoMerger.js
+++ b/src/RepoMerger.js
@@ -47,7 +47,7 @@ class RepoMerger {
         });
     }
 
-    // prIds (if provided) an array of Util.PrId elements
+    // prIds (if provided) an array of Util.PrId elements filled by an event
     async run(prIds, handler) {
         if (handler)
             this._handler = handler;

--- a/src/RepoMerger.js
+++ b/src/RepoMerger.js
@@ -47,10 +47,7 @@ class RepoMerger {
         });
     }
 
-    // prIds (if provided) an array of elements, each represents:
-    // a PR number as an integer, or
-    // a PR branch name as a string (without 'refs' or 'heads' prefixes), or
-    // a staging branch commit SHA as a string (including stale commits).
+    // prIds (if provided) an array of Util.PrId elements
     async run(prIds, handler) {
         if (handler)
             this._handler = handler;

--- a/src/RepoMerger.js
+++ b/src/RepoMerger.js
@@ -47,7 +47,7 @@ class RepoMerger {
         });
     }
 
-    // prIds (if provided) an array of Util.PrId elements filled by an event
+    // prIds is an array of Util.PrId objects collected by event handlers (or null)
     async run(prIds, handler) {
         assert(prIds !== undefined);
 
@@ -58,7 +58,7 @@ class RepoMerger {
             this._prIds = null;
         else if (this._prIds !== null)
             this._prIds.push(...prIds);
-        // else keep discarding prIds until next rerun (prIds !== null && this._prIds === null)
+        // else keep discarding prIds until this._prIds is reset below
 
         if (this._running) {
             Logger.info("Already running, planning rerun.");
@@ -71,7 +71,7 @@ class RepoMerger {
         do {
             try {
                 this._rerun = false;
-                const ids = this._prIds;
+                const ids = this._prIds; // may be null
                 this._prIds = [];
                 if (!this._server)
                     await this._createServer();

--- a/src/Util.js
+++ b/src/Util.js
@@ -90,6 +90,8 @@ class PrId
     static PrNumList(list) { return Array.from(list, prNum => new PrId("prNum", prNum.toString())); }
 
     isEmpty() { return this.type === null; }
+
+    toString() { return `${this.type}:${this.value}`; }
 }
 
 module.exports = {

--- a/src/Util.js
+++ b/src/Util.js
@@ -70,17 +70,17 @@ class ErrorContext extends Error {
 // staging branch commit SHA (including stale commits).
 class PrId
 {
-    constructor(type, val) {
+    constructor(type, val, msg) {
         assert(type !== undefined);
         assert(type !== null);
         assert(val !== undefined);
         assert(val !== null);
         this.type = type; // a PR identificator type ("branch", "sha" or "prNum")
         this.value = val; // a PR identificator
+        this.message = (msg === undefined) ? null : msg; // the commit message or null
     }
 
-    static Branch(branch) { return [new PrId("branch", branch)]; }
-    static BranchList(branches) { return Array.from(branches, b => new PrId("branch", b)); }
+    static BranchList(branches, msg) { return Array.from(branches, b => new PrId("branch", b, msg)); }
     static Sha(sha) { return [new PrId("sha", sha)]; }
     static PrNum(prNum) { return [new PrId("prNum", prNum.toString())]; }
     static PrNumList(list) { return Array.from(list, prNum => new PrId("prNum", prNum.toString())); }

--- a/src/Util.js
+++ b/src/Util.js
@@ -26,6 +26,15 @@ function ParsePrNumber(prMessage) {
     return prNumber;
 }
 
+function DateForDaysAgo(days) {
+    let d = new Date();
+    d.setDate(d.getDate() - days);
+    const dd = String(d.getDate()).padStart(2, '0');
+    const mm = String(d.getMonth() + 1).padStart(2, '0'); //January is 0!
+    const yyyy = d.getFullYear();
+    return yyyy + '-' + mm + '-' + dd;
+}
+
 // An error context for promisificated wrappers.
 class ErrorContext extends Error {
     // The underlying rejection may be a bot-specific Promise.reject() or
@@ -68,6 +77,7 @@ module.exports = {
     sleep: sleep,
     commonParams: commonParams,
     ParsePrNumber: ParsePrNumber,
-    ErrorContext: ErrorContext
+    ErrorContext: ErrorContext,
+    DateForDaysAgo: DateForDaysAgo
 };
 

--- a/src/Util.js
+++ b/src/Util.js
@@ -71,7 +71,7 @@ class ErrorContext extends Error {
 class PrId
 {
     constructor(type, val) {
-        assert(type !== undefined && id !== undefined);
+        assert(type !== undefined && val !== undefined);
         this.type = type; // a PR identificator type ("branch", "sha", "prNum") or null
         this.value = val; // a PR identificator or null
     }

--- a/src/Util.js
+++ b/src/Util.js
@@ -26,15 +26,6 @@ function ParsePrNumber(prMessage) {
     return prNumber;
 }
 
-function DateForDaysAgo(days) {
-    let d = new Date();
-    d.setDate(d.getDate() - days);
-    const dd = String(d.getDate()).padStart(2, '0');
-    const mm = String(d.getMonth() + 1).padStart(2, '0'); //January is 0!
-    const yyyy = d.getFullYear();
-    return yyyy + '-' + mm + '-' + dd;
-}
-
 // An error context for promisificated wrappers.
 class ErrorContext extends Error {
     // The underlying rejection may be a bot-specific Promise.reject() or
@@ -77,7 +68,6 @@ module.exports = {
     sleep: sleep,
     commonParams: commonParams,
     ParsePrNumber: ParsePrNumber,
-    ErrorContext: ErrorContext,
-    DateForDaysAgo: DateForDaysAgo
+    ErrorContext: ErrorContext
 };
 

--- a/src/Util.js
+++ b/src/Util.js
@@ -64,10 +64,39 @@ class ErrorContext extends Error {
     }
 }
 
+// Represents a PR 'identificator' as a string, which may be one of
+// a PR number, or
+// a PR branch name (without 'refs' or 'heads' prefixes), or
+// a staging branch commit SHA (including stale commits).
+class PrId
+{
+    constructor(type, val) {
+        assert(type !== undefined && id !== undefined);
+        this.type = type; // a PR identificator type ("branch", "sha", "prNum") or null
+        this.value = val; // a PR identificator or null
+    }
+
+    static Empty() { return [new PrId(null, null)]; }
+    static Branch(branch) { return [new PrId("branch", branch)]; }
+    static BranchList(branches) { return Array.from(branches, b => new PrId("branch", b)); }
+    static Sha(sha) { return [new PrId("sha", sha)]; }
+    static PrNum(prNum) { return [new PrId("prNum", prNum.toString())]; }
+    static PrMessage(message) {
+        const prNum = ParsePrNumber(message);
+        if (prNum !== null)
+            return [new PrId("prNum", prNum)];
+        return PrId.Empty();
+    }
+    static PrNumList(list) { return Array.from(list, prNum => new PrId("prNum", prNum.toString())); }
+
+    isEmpty() { return this.type === null; }
+}
+
 module.exports = {
     sleep: sleep,
     commonParams: commonParams,
     ParsePrNumber: ParsePrNumber,
-    ErrorContext: ErrorContext
+    ErrorContext: ErrorContext,
+    PrId: PrId,
 };
 

--- a/src/Util.js
+++ b/src/Util.js
@@ -71,25 +71,19 @@ class ErrorContext extends Error {
 class PrId
 {
     constructor(type, val) {
-        assert(type !== undefined && val !== undefined);
+        assert(type !== undefined);
+        assert(type !== null);
+        assert(val !== undefined);
+        assert(val !== null);
         this.type = type; // a PR identificator type ("branch", "sha", "prNum") or null
         this.value = val; // a PR identificator or null
     }
 
-    static Empty() { return [new PrId(null, null)]; }
     static Branch(branch) { return [new PrId("branch", branch)]; }
     static BranchList(branches) { return Array.from(branches, b => new PrId("branch", b)); }
     static Sha(sha) { return [new PrId("sha", sha)]; }
     static PrNum(prNum) { return [new PrId("prNum", prNum.toString())]; }
-    static PrMessage(message) {
-        const prNum = ParsePrNumber(message);
-        if (prNum !== null)
-            return [new PrId("prNum", prNum)];
-        return PrId.Empty();
-    }
     static PrNumList(list) { return Array.from(list, prNum => new PrId("prNum", prNum.toString())); }
-
-    isEmpty() { return this.type === null; }
 
     toString() { return `${this.type}:${this.value}`; }
 }

--- a/src/Util.js
+++ b/src/Util.js
@@ -64,7 +64,7 @@ class ErrorContext extends Error {
     }
 }
 
-// Represents a PR 'identificator' as a string, either of
+// Identifies or refers to a PR using either
 // PR number, or
 // PR branch name (without 'refs' or 'heads' prefixes), or
 // staging branch commit SHA (including stale commits).

--- a/src/Util.js
+++ b/src/Util.js
@@ -64,10 +64,10 @@ class ErrorContext extends Error {
     }
 }
 
-// Represents a PR 'identificator' as a string, which may be one of
-// a PR number, or
-// a PR branch name (without 'refs' or 'heads' prefixes), or
-// a staging branch commit SHA (including stale commits).
+// Represents a PR 'identificator' as a string, either of
+// PR number, or
+// PR branch name (without 'refs' or 'heads' prefixes), or
+// staging branch commit SHA (including stale commits).
 class PrId
 {
     constructor(type, val) {

--- a/src/Util.js
+++ b/src/Util.js
@@ -75,8 +75,8 @@ class PrId
         assert(type !== null);
         assert(val !== undefined);
         assert(val !== null);
-        this.type = type; // a PR identificator type ("branch", "sha", "prNum") or null
-        this.value = val; // a PR identificator or null
+        this.type = type; // a PR identificator type ("branch", "sha" or "prNum")
+        this.value = val; // a PR identificator
     }
 
     static Branch(branch) { return [new PrId("branch", branch)]; }

--- a/src/Util.js
+++ b/src/Util.js
@@ -21,7 +21,8 @@ function ParsePrNumber(prMessage) {
     const matched = lines[0].match(PrNumberRegex);
     if (!matched)
         return null;
-    const prNumber = matched[1];
+    const prNumber = parseInt(matched[1], 10);
+    assert(!isNaN(prNumber));
     assert(prNumber > 0);
     return prNumber;
 }
@@ -82,8 +83,8 @@ class PrId
 
     static BranchList(branches, msg) { return Array.from(branches, b => new PrId("branch", b, msg)); }
     static Sha(sha) { return [new PrId("sha", sha)]; }
-    static PrNum(prNum) { return [new PrId("prNum", prNum.toString())]; }
-    static PrNumList(list) { return Array.from(list, prNum => new PrId("prNum", prNum.toString())); }
+    static PrNum(prNum) { return [new PrId("prNum", prNum)]; }
+    static PrNumList(list) { return Array.from(list, prNum => new PrId("prNum", prNum)); }
 
     toString() { return `${this.type}:${this.value}`; }
 }


### PR DESCRIPTION
The recently added 265a79a optimization relied on PR::updated_at field
to track all PR-related changes. However, this proved to be wrong: for
example, PR or staged commit statuses do not update this field. Now we
get the missing information from incoming GitHub events.