### PR TITLE
Do not ignore PRs with M-cleared-for-merge

### DIFF
--- a/src/PrMerger.js
+++ b/src/PrMerger.js
@@ -14,6 +14,10 @@ class PrScanResult {
     }
 
     isStillUnchanged(freshRawPr, freshScanDate) {
+        const clearedForMerge = freshRawPr.labels.some(el => el.name === Config.clearedForMergeLabel());
+        // If a PR A was cleared for merge, it may be ready for merge (no updates are expected).
+        if (clearedForMerge)
+            return false;
         const savedRawPr = this.awakePrs.find(el => el.number === freshRawPr.number);
         if (!savedRawPr)
             return false; // this scan has not seen freshRawPR


### PR DESCRIPTION
We should bypass the idle PR optimization in this case
because cleared-for-merge PRs may be ready for merge
without additional GitHub activity.