### PR TITLE
Discard PR scan optimization on a top-level exception

### DIFF
--- a/src/RepoMerger.js
+++ b/src/RepoMerger.js
@@ -78,6 +78,7 @@ class RepoMerger {
             } catch (e) {
                 Log.LogError(e, "RepoMerger.run");
                 this._rerun = true;
+                this._prIds = null;
                 Logger.info("closing HTTP server");
                 this._server.close(this._onServerClosed.bind(this));
 


### PR DESCRIPTION
Such exceptions may leave the PR cache in an incoherent state (e.g.,
PrMerger._LastScan may not get the calculated value yet).  In
these situations we should start PR scanning from scratch.
