### PR TITLE
Ignore irrelevant PRs in check_run/workflow_run events

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -87,6 +87,7 @@ class ConfigOptions {
     host() { return this._host; }
     port() { return this._port; }
     owner() { return this._owner; }
+    baseUrl() { return 'https://api.github.com'; }
     stagingBranchPath() { return "heads/" + this._stagingBranch; }
     stagingBranch() { return this._stagingBranch; }
     dryRun() { return this._dryRun; }

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -8,7 +8,7 @@ const GitHub = new Octokit({
         fetch: undefined,
         timeout: Config.requestTimeout(),
     },
-    baseUrl: 'https://api.github.com'
+    baseUrl: Config.baseUrl()
 });
 const Util = require('./Util.js');
 const Log = require('./Logger.js');


### PR DESCRIPTION
These events may carry information about PRs unrelated to Squid Project.
For example, an organization X may create a PR that tries to merge one
of Squid official branches into their own branch, and GitHub starts to
supply check_runs created for Squid official commits with X's PR
numbers.