### PR TITLE
Detail M-failed-description reasons via GitHub comments

### DIFF
--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -234,6 +234,26 @@ export async function removeLabel(label, prNum) {
     return await rateLimitedPromise(result);
 }
 
+export async function createComment(prNum, comment) {
+    assert(!Config.dryRun());
+    let params = commonParams();
+    params.issue_number = prNum;
+    params.body = comment;
+
+    const result = await GitHub.rest.issues.createComment(params);
+    logApiResult(createComment.name, params, {created: true});
+    return await rateLimitedPromise(result);
+}
+
+export async function getComments(prNum) {
+    let params = commonParams();
+    params.issue_number = prNum;
+
+    const comments = await paginatedGet(GitHub.rest.issues.listComments, params);
+    logApiResult(getComments.name, params, {comments: comments.length});
+    return comments;
+}
+
 // XXX: remove if not needed, since the "required_status_checks" api call sometimes
 // does not work(?) for organization repositories (returns 404 Not Found).
 //async function getProtectedBranchRequiredStatusChecks(branch) {

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -234,26 +234,6 @@ export async function removeLabel(label, prNum) {
     return await rateLimitedPromise(result);
 }
 
-export async function createComment(prNum, comment) {
-    assert(!Config.dryRun());
-    let params = commonParams();
-    params.issue_number = prNum;
-    params.body = comment;
-
-    const result = await GitHub.rest.issues.createComment(params);
-    logApiResult(createComment.name, params, {created: true});
-    return await rateLimitedPromise(result);
-}
-
-export async function getComments(prNum) {
-    let params = commonParams();
-    params.issue_number = prNum;
-
-    const comments = await paginatedGet(GitHub.rest.issues.listComments, params);
-    logApiResult(getComments.name, params, {comments: comments.length});
-    return comments;
-}
-
 // XXX: remove if not needed, since the "required_status_checks" api call sometimes
 // does not work(?) for organization repositories (returns 404 Not Found).
 //async function getProtectedBranchRequiredStatusChecks(branch) {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -110,7 +110,7 @@ class PrDescriptionProblem extends PrProblem
             const escaped = EscapeUnsafeCharacters(this._problematicInput);
             // the encoded length is 6: e.g., \u00E9
             const badCharEncoded = escaped.substring(match.index, match.index + 6);
-            errorMessage += `Invalid ${this._parsingContext} character (Unicode ${badCharEncoded}) at position ${match.index}:\n`;
+            errorMessage += `\`Invalid ${this._parsingContext} character (Unicode ${badCharEncoded}) at position ${match.index}\`:\n`;
         } else {
             errorMessage += `\`${this._errorDescription}\`:\n`;
         }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -118,11 +118,14 @@ class PrDescriptionProblem extends PrProblem
         }
 
         if (this._problematicInput) {
-            const escaped = EscapeUnsafeCharacters(this._problematicInput);
+            // We expect that input contains no new lines. If our expectations are wrong, then
+            // EscapeUnsafeCharacters() should escape/replace any new lines, and the indentation
+            // trick below should still work.
+            const escapedLine = EscapeUnsafeCharacters(this._problematicInput);
             // indent with 4 spaces to ask GitHub to render user input without Markdown formatting
-            errorMessage += `\nProblematic parser input:\n\n    ${escaped}\n`;
+            errorMessage += `\nProblematic parser input:\n\n    ${escapedLine}\n`;
 
-            if (escaped !== this._problematicInput) {
+            if (escapedLine !== this._problematicInput) {
                 errorMessage += 'Please note that the text quoted above was modified from its original to replace ';
                 errorMessage += 'bytes outside of ASCII space-tilde range with their Unicode code point sequences (i.e. \\u00NN). ';
             }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -102,7 +102,7 @@ class PrDescriptionProblem extends PrProblem
     // creates a Markdown text suitable for being a second GitHubUtil::createComment() parameter
     toGitHubComment() {
         let errorMessage = `Cannot create a git commit message from PR title and description.\n\n`;
-        errorMessage += `Invalid ${this._parsingContext}: `;
+        errorMessage += `Invalid PR description ${this._parsingContext}: `;
 
         if (this._errorDescription === ErrorDescriptionInvalidCharacter) {
             const match = Util.PrMessageProhibitedCharacters.exec(this._problematicInput);
@@ -660,7 +660,7 @@ class CommitMessage
 
     _parseTitle(rawTitle, prNumber) {
         const title = rawTitle.trim();
-        const parsingContext = "PR description title";
+        const parsingContext = "title";
         this._checkRawCharacters(title, parsingContext);
         // the (required) commit message title
         this._title = title + ' (#' + prNumber + ')';
@@ -704,7 +704,7 @@ class CommitMessage
         let lines = [];
         for (let i = 0; i < untrimmedLines.length; ++i) {
             let untrimmedLine = untrimmedLines[i];
-            const parsingContext = `PR description line ${i+1}`;
+            const parsingContext = `line ${i+1}`;
             this._checkRawCharacters(untrimmedLine, parsingContext);
             // allow excessively long whitespace-only lines
             // that some copy-pasted PR descriptions may include
@@ -771,7 +771,7 @@ class CommitMessage
         const prDescription = this._trim(prDescriptionRaw);
         const headerFieldName = 'Authored-by';
         if (this._startsWithFieldName(prDescription) === headerFieldName) {
-            const parsingContext = "PR description header";
+            const parsingContext = "header";
             let tokenizer = new FieldsTokenizer(prDescription, parsingContext);
             const authorField = tokenizer.nextField();
             assert(authorField);
@@ -805,7 +805,7 @@ class CommitMessage
     _parseBody(prDescriptionWithoutHeaderAndTrailerRaw) {
         const prDescriptionWithoutHeaderAndTrailer = this._trim(prDescriptionWithoutHeaderAndTrailerRaw);
         if (prDescriptionWithoutHeaderAndTrailer.length > 0) {
-            const parsingContext = "PR description body";
+            const parsingContext = "body";
             this._checkMessageLength(prDescriptionWithoutHeaderAndTrailer, parsingContext);
             this._checkForTypos(prDescriptionWithoutHeaderAndTrailer, parsingContext);
             this._body = prDescriptionWithoutHeaderAndTrailer;
@@ -815,7 +815,7 @@ class CommitMessage
     // parses the extracted trailer into this._trailer
     _parseTrailer(trailerRaw) {
         const trailer = this._trim(trailerRaw);
-        const parsingContext = "PR description trailer";
+        const parsingContext = "trailer";
         let tokenizer = new FieldsTokenizer(trailer, parsingContext);
 
         if (tokenizer.atEnd())

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -553,10 +553,81 @@ class FieldsTokenizer
     remaining() { return this._lines.join('\n'); }
 }
 
+class CommitMessageProblem
+{
+    constructor(name, level) {
+        assert(name !== undefined && name !== null);
+        assert(level >= 0);
+        this.name = name;
+        this.level = level;
+        this.problems = [];
+        this.subProblems = [];
+    }
+
+    subProblem(name) {
+        let problem = this.subProblems.find(p => p.name === name);
+        assert(problem !== undefined);
+        return problem;
+    }
+
+    empty() {
+        return !this.problems.length && this.subProblems.every(p => p.empty());
+    }
+
+    add(message) {
+        this.problems.push(message);
+    }
+
+    _offset() {
+        let offset = "";
+        for (let i = 0; i < this.level; ++i)
+            offset += "    ";
+        return offset;
+    }
+
+    toString() {
+        if (this.empty())
+            return "";
+        let str = this._offset() + "* " + this.name + '\n';
+        for (let p of this.problems)
+            str += this._offset() + "    " + "* " + p + '\n';
+        for (let s of this.subProblems) {
+            if (!s.empty())
+                str += s.toString();
+        }
+        return str;
+    }
+}
+
+class CommitMessageErrors
+{
+    constructor() {
+        this.title = new CommitMessageProblem("title", 0);
+        this.message = new CommitMessageProblem("message", 0);
+        this.message.subProblems.push(new CommitMessageProblem("header", 1));
+        this.message.subProblems.push(new CommitMessageProblem("body", 1));
+        this.message.subProblems.push(new CommitMessageProblem("trailer", 1));
+    }
+    empty() { return this.title.empty() && this.message.empty(); }
+
+    toString() {
+        if (this.empty())
+            return "";
+
+        let str = "";
+        if (!this.title.empty())
+            str += this.title.toString();
+        if (!this.message.empty())
+            str += this.message.toString();
+        return str;
+    }
+}
+
 // computes future commit message from raw PR
 class CommitMessage
 {
     constructor(rawPr, defaultAuthor, stageable) {
+        this.errors = new CommitMessageErrors();
 
         this._parseTitle(rawPr.title, rawPr.number);
 
@@ -593,10 +664,21 @@ class CommitMessage
 
     _parseTitle(rawTitle, prNumber) {
         const title = rawTitle.trim();
-        this._checkRawCharacters(title);
-        // the (required) commit message title
-        this._title = title + ' (#' + prNumber + ')';
-        checkLineLength(this._title);
+        try {
+            this._checkRawCharacters(title);
+        } catch (e) {
+            let coloredMsg = this.colorUnicode(e.message);
+      //      let escaptedMsg = this.escapeUnicode(coloredMsg);
+            this.errors.title.add(coloredMsg);
+        }
+
+        try {
+            // the (required) commit message title
+            this._title = title + ' (#' + prNumber + ')';
+            checkLineLength(this._title);
+        } catch (e) {
+            this.errors.title.add(e.message);
+        }
     }
 
     // complete message for the future commit
@@ -616,6 +698,23 @@ class CommitMessage
         if (this._customAuthor === null)
             return this._defaultAuthor;
         return {name: this._customAuthor.name, email: this._customAuthor.email, date: this._defaultAuthor.date};
+    }
+
+    escapeUnicode(str) {
+        return str.replace(/[^\u{20}-\u{7e}]/gu, function(char,offset) {
+            let codePoint = char.charCodeAt(0).toString(16).toUpperCase();
+            // Pad with leading zeros to ensure 4 digits (e.g., \u00E9)
+            while (codePoint.length < 4) {
+              codePoint = '0' + codePoint;
+            }
+            return '\\u' + codePoint;
+        });
+    }
+
+    colorUnicode(str) {
+        return str.replace(/[^\u{20}-\u{7e}]+/gu, function(s,offset) {
+            return '$${\\color{red}'+s + '}$$';
+        });
     }
 
     // checks that the line represents only ASCII_printable characters
@@ -675,10 +774,33 @@ class CommitMessage
     }
 
     _parse(prDescriptionRaw) {
-        const prDescription = this._parseRawLines(prDescriptionRaw);
-        const prDescriptionWithoutHeader = this._extractHeader(prDescription);
-        const prDescriptionWithoutHeaderAndTrailer = this._extractTrailer(prDescriptionWithoutHeader);
-        this._parseBody(prDescriptionWithoutHeaderAndTrailer);
+        try {
+            const prDescription = this._parseRawLines(prDescriptionRaw);
+            let prDescriptionWithoutHeader = null;
+            try {
+                prDescriptionWithoutHeader = this._extractHeader(prDescription);
+            } catch (e) {
+                this.errors.message.subProblem("header").add(e.message);
+                return;
+            }
+
+            let prDescriptionWithoutHeaderAndTrailer = null;
+            try {
+                prDescriptionWithoutHeaderAndTrailer = this._extractTrailer(prDescriptionWithoutHeader);
+            } catch (e) {
+                this.errors.message.subProblem("trailer").add(e.message);
+                return;
+            }
+
+            try {
+                this._parseBody(prDescriptionWithoutHeaderAndTrailer);
+            } catch (e) {
+                this.errors.message.subProblem("body").add(e.message);
+                return;
+            }
+        } catch (e) {
+            this.errors.message.add(e.message);
+        }
     }
 
     // authorField is a {name, value, raw}
@@ -1392,10 +1514,11 @@ class PullRequest {
             defaultAuthor = headCommit.author;
         }
 
-        try {
-            this._commitMessage = new CommitMessage(this._rawPr, defaultAuthor, stageable);
-        } catch (e) {
-            this._logEx(e, "cannot parse commit message");
+        this._commitMessage = new CommitMessage(this._rawPr, defaultAuthor, stageable);
+        if (!this._commitMessage.errors.empty()) {
+             this._log(this._commitMessage.errors.toString());
+             await GH.createComment(this._prNumber(), this._commitMessage.errors.toString());
+            // XXX:  this._logEx(e, "cannot parse commit message");
         }
     }
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -112,7 +112,7 @@ class PrDescriptionProblem extends PrProblem
             const badCharEncoded = escaped.substring(match.index, match.index + 6);
             errorMessage += `Invalid ${this._parsingContext} character (Unicode ${badCharEncoded}) at position ${match.index}:\n`;
         } else {
-            errorMessage += this._errorDescription + ":\n";
+            errorMessage += `\`${this._errorDescription}\`:\n`;
         }
 
         if (this._problematicInput) {

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -633,8 +633,7 @@ class CommitMessage
 
      // checks that the line does not contain _prohibitedCharacters
     _checkRawCharacters(line, context) {
-        if (line.length === 0)
-            return;
+        assert(context.length);
         const match = this._prohibitedCharacters.exec(line);
         if (match) {
             const escaped = this.escapeUnicode(line);
@@ -654,7 +653,7 @@ class CommitMessage
         let lines = [];
         for (let i = 0; i < untrimmedLines.length; ++i) {
             let untrimmedLine = untrimmedLines[i];
-            const parsingContext = `PR description (line ${i+1}`;
+            const parsingContext = `PR description line ${i+1}`;
             this._checkRawCharacters(untrimmedLine, parsingContext);
             // allow excessively long whitespace-only lines
             // that some copy-pasted PR descriptions may include

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -686,7 +686,7 @@ class CommitMessage
         return {name: this._customAuthor.name, email: this._customAuthor.email, date: this._defaultAuthor.date};
     }
 
-     // checks that the line does not contain _prohibitedCharacters
+    // checks that the line does not contain _prohibitedCharacters
     _checkRawCharacters(line, context) {
         assert(context.length);
         const match = Util.PrMessageProhibitedCharacters.exec(line);

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1479,11 +1479,13 @@ class PullRequest {
 
             const comments = await GH.getComments(this._prNumber());
             const filtered = comments.filter(c => c.user.login === Config.githubUserLogin());
-            const lastComment = filtered.length ? filtered[filtered.length-1].body : null;
             const newComment = e.toGitHubComment();
-            // remove CRs in CRLF sequences (added by GitHub after saving edited messages)
-            const adjustedLastComment = lastComment.replace(/\r+\n/g, '\n');
-            if (newComment !== adjustedLastComment)
+            let lastComment = filtered.length ? filtered[filtered.length-1].body : null;
+            if (lastComment) {
+                // remove CRs in CRLF sequences (added by GitHub after saving edited messages)
+                lastComment = lastComment.replace(/\r+\n/g, '\n');
+            }
+            if (newComment !== lastComment)
                 await GH.createComment(this._prNumber(), newComment);
             else
                 this._log(`not duplicating the last GitHub comment: ${lastComment}`);

--- a/src/Util.js
+++ b/src/Util.js
@@ -16,6 +16,8 @@ export function commonParams() {
 
 const PrNumberRegex = / \(#(\d+)\)$/;
 
+export const PrMessageProhibitedCharacters = new RegExp("[^\u{20}-\u{7e}]", "u");
+
 export function ParsePrNumber(prMessage) {
     assert(prMessage);
     const lines = prMessage.split(/\r*\n/);

--- a/src/Util.js
+++ b/src/Util.js
@@ -16,7 +16,8 @@ export function commonParams() {
 
 const PrNumberRegex = / \(#(\d+)\)$/;
 
-export const PrMessageProhibitedCharacters = new RegExp("[^\u{20}-\u{7e}]", "u");
+// this regex is applied to individual PR title and description lines, so we do not need to allow LF
+export const ProhibitedCommitMessageLineCharacters = new RegExp("[^\u{20}-\u{7e}]", "u");
 
 export function ParsePrNumber(prMessage) {
     assert(prMessage);


### PR DESCRIPTION
Add a GitHub PR comment to detail PR title or description validation
failures. Such failures already set or preserve an M-failed-description
PR label, but humans often cannot easily guess what is wrong with their
PR title or description, resulting in bad UX.

For now, only the first validation failure is reported/explained.

Another GitHub comment is added only if its text would differ from the
previous Anubis-added comment. Avoiding duplicates requires fetching
past PR comments. It remains to be seen whether fetching _all_ past PR
comments is too expensive. Unfortunately, GitHub API does not allow
querying comments by their author or keyword.