### PR TITLE
Fix PR association with workflow_run/check_run events

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -107,9 +107,10 @@ function handleCheckEvent(name, e) {
     if (e.head_branch === Config.stagingBranch()) {
         return Util.PrId.Sha(e.head_sha);
     }
-    // check/workflow events for other non-PR branches (e.g., master) are not associated with PRs
-    Logger.info(`${name} event: no PR for`, e.head_sha);
-    return [];
+
+    // Check/workflow events for other branches.
+    // Will check for PR association later.
+    return Util.PrId.BranchList([e.head_branch], null);
 }
 
 // https://docs.github.com/ru/webhooks/webhook-events-and-payloads#workflow_run

--- a/src/Main.js
+++ b/src/Main.js
@@ -104,12 +104,15 @@ function handleCheckEvent(name, e) {
         return [];
     }
 
+    if (e.head_branch === undefined) {
+        Logger.info(`${name} event: no e.head_branch`, e.head_sha);
+        return [];
+    }
+
     if (e.head_branch === Config.stagingBranch()) {
         return Util.PrId.Sha(e.head_sha);
     }
 
-    // Check/workflow events for other branches.
-    // Will check for PR association later.
     return Util.PrId.BranchList([e.head_branch], null);
 }
 


### PR DESCRIPTION
GitHub has been removing PR information from check_run and worflow_run
events (especially for forks), returning empty pull_requests array in
the events payload. Anubis could not get this information to associate
the events with monitoring PRs:

    "check_run event: no PR for ..."
    "workflow_run event: no PR for ..."

Now Anubis extracts PR branch name from these events, and searches
an open PR with the same branch name. This approach has been already
applied for 'status' and 'push' events.
