### PR TITLE
Wait for status checks to be copied before attempting to merge

### DIFF
--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -270,26 +270,6 @@ export async function getComments(prNum) {
     return comments;
 }
 
-// XXX: remove if not needed, since the "required_status_checks" api call sometimes
-// does not work(?) for organization repositories (returns 404 Not Found).
-//async function getProtectedBranchRequiredStatusChecks(branch) {
-//    let params = commonParams();
-//    params.branch = branch;
-//    const promise = new Promise( (resolve, reject) => {
-//      GitHub.authenticate(GitHubAuthentication);
-//      GitHub.repos.getProtectedBranchRequiredStatusChecks(params, (err, res) => {
-//          if (err) {
-//             reject(new ErrorContext(err, getProtectedBranchRequiredStatusChecks.name, params));
-//             return;
-//          }
-//          const result = {checks: res.data.contexts.length};
-//          logApiResult(getProtectedBranchRequiredStatusChecks.name, params, result);
-//          resolve(res);
-//      });
-//    return (await rateLimitedPromise(promise)).contexts;
-//    });
-//}
-
 export async function createStatus(sha, state, targetUrl, description, context) {
     assert(!Config.dryRun());
 

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -81,21 +81,38 @@ export async function getLabels(prNum) {
     return await rateLimitedPromise(result);
 }
 
+/// For waitFor() code to signal that more iterations are needed
+const TryAgain = Symbol("TryAgain");
+
+// (Re)runs `code` while it returns a TryAgain value, waiting between retries.
+// Meant for `code` that makes GitHub API call(s) that may not succeed on the
+// first try.
+async function waitFor(description, code) {
+    // this limits total wait time to about 2 minutes
+    const singleWaitMax = 64; // seconds
+    for (let singleWait = 1; singleWait <= singleWaitMax; singleWait *= 2) {
+        const result = await code();
+        if (result !== TryAgain) {
+            Log.Logger.info(`Done waiting for ${description}`);
+            return result;
+        }
+        Log.Logger.info(`Still waiting for ${description}. Will retry in ${singleWait} seconds`);
+        await Util.sleep(singleWait*1000);
+    }
+    throw new ErrorContext(`Timed out waiting for ${description}`, waitFor.name);
+}
+
 // Gets PR metadata from GitHub
 // If requested and needed, retries until GitHub calculates PR mergeable flag.
 // Those retries, if any, are limited to a few minutes.
 export async function getPR(prNum, awaitMergeable) {
-    const max = 64 * 1000 + 1; // ~2 min. overall
-    for (let d = 1000; d < max; d *= 2) {
+    return await waitFor('GitHub to calculate mergeable attribute', async () => {
         const pr = await getRawPR(prNum);
         // pr.mergeable is useless (and not calculated?) for a closed PR
         if (pr.mergeable !== null || pr.state === 'closed' || !awaitMergeable)
             return pr;
-        Log.Logger.info("PR" + prNum + ": GitHub still calculates mergeable attribute. Will retry in " + (d/1000) + " seconds");
-        await Util.sleep(d);
-    }
-    return Promise.reject(new ErrorContext("Timed out waiting for GitHub to calculate mergeable attribute",
-                getPR.name, {pr: prNum}));
+        return TryAgain;
+    });
 }
 
 // gets a PR from GitHub (as is)
@@ -274,26 +291,6 @@ export async function getComments(prNum) {
 //    });
 //}
 
-async function getStatus(ref, context) {
-    let params = commonParams();
-    params.ref = ref;
-
-    const max = 64 * 1000 + 1; // ~2 min. overall
-    for (let d = 1000; d < max; d *= 2) {
-        const result = await GitHub.rest.repos.getCombinedStatusForRef(params);
-        const statuses = result.data.statuses;
-        if (statuses.some(st => st.context === context)) {
-            Log.Logger.info("Verified that GitHub has successfully created " + context + " status for the " + ref + " commit.");
-            return true;
-        }
-        Log.Logger.info("GitHub is still applying " + context + " status to the " + ref + " commit. Will retry in " + (d/1000) + " seconds");
-        await Util.sleep(d);
-    }
-
-    return Promise.reject(new ErrorContext("Timed out waiting for GitHub to create commit status",
-                getStatus.name, {ref: ref, context: context}));
-}
-
 export async function createStatus(sha, state, targetUrl, description, context) {
     assert(!Config.dryRun());
 
@@ -305,9 +302,21 @@ export async function createStatus(sha, state, targetUrl, description, context) 
     params.context = context;
 
     const result = await GitHub.rest.repos.createCommitStatus(params);
-    await getStatus(sha, context);
     logApiResult(createStatus.name, params, {context: result.data.context});
-    return (await rateLimitedPromise(result)).context;
+    await rateLimitedPromise(result);
+
+    const checkParams = commonParams();
+    checkParams.ref = sha;
+    await waitFor(`GitHub to create ${context} status for the ${sha} commit`, async () => {
+        const checkResult = await GitHub.rest.repos.getCombinedStatusForRef(checkParams);
+        await rateLimitedPromise(checkResult);
+        const statuses = checkResult.data.statuses;
+        if (statuses.some(st => st.context === context))
+            return statuses;
+        return TryAgain;
+    });
+
+    return result.data.context;
 }
 
 export async function getProtectedBranchRequiredStatusChecks(branch) {

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -14,7 +14,6 @@ const GitHub = new Octokit({
     },
     baseUrl: Config.baseUrl()
 });
-const ErrorContext = Util.ErrorContext;
 const commonParams = Util.commonParams;
 const logApiResult = Log.logApiResult;
 
@@ -99,7 +98,7 @@ async function waitFor(description, code) {
         Log.Logger.info(`Still waiting for ${description}. Will retry in ${singleWait} seconds`);
         await Util.sleep(singleWait*1000);
     }
-    throw new ErrorContext(`Timed out waiting for ${description}`, waitFor.name);
+    throw new Error(`Timed out waiting for ${description}`);
 }
 
 // Gets PR metadata from GitHub

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -274,6 +274,26 @@ export async function getComments(prNum) {
 //    });
 //}
 
+async function getStatus(ref, context) {
+    let params = commonParams();
+    params.ref = ref;
+
+    const max = 64 * 1000 + 1; // ~2 min. overall
+    for (let d = 1000; d < max; d *= 2) {
+        const result = await GitHub.rest.repos.getCombinedStatusForRef(params);
+        const statuses = result.data.statuses;
+        if (statuses.some(st => st.context === context)) {
+            Log.Logger.info("Verified that GitHub has successfully created " + context + " status for the " + ref + " commit.");
+            return true;
+        }
+        Log.Logger.info("GitHub is still applying " + context + " status to the " + ref + " commit. Will retry in " + (d/1000) + " seconds");
+        await Util.sleep(d);
+    }
+
+    return Promise.reject(new ErrorContext("Timed out waiting for GitHub to create commit status",
+                getStatus.name, {ref: ref, context: context}));
+}
+
 export async function createStatus(sha, state, targetUrl, description, context) {
     assert(!Config.dryRun());
 
@@ -285,6 +305,7 @@ export async function createStatus(sha, state, targetUrl, description, context) 
     params.context = context;
 
     const result = await GitHub.rest.repos.createCommitStatus(params);
+    await getStatus(sha, context);
     logApiResult(createStatus.name, params, {context: result.data.context});
     return (await rateLimitedPromise(result)).context;
 }

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -453,7 +453,7 @@ class Labels
         try {
             await GH.removeLabel(name, this._prNum);
         } catch (e) {
-            if (e.name === 'ErrorContext' && e.notFound()) {
+            if (e instanceof RequestError && e.status === 404) {
                 Log.LogException(e, "_removeFromGitHub: " + name + " not found");
                 return;
             }
@@ -1040,7 +1040,7 @@ class PullRequest {
         try {
             this._contextsRequiredByGitHubConfig = await GH.getProtectedBranchRequiredStatusChecks(this._prBaseBranch());
         } catch (e) {
-           if (e.name === 'ErrorContext' && e.notFound())
+           if (e instanceof RequestError && e.status === 404)
                this._logEx(e, "no status checks are required");
            else
                throw e;
@@ -1676,7 +1676,8 @@ class PullRequest {
         try {
             await GH.updateReference(this._prBaseBranchPath(), this._stagedSha(), false);
         } catch (e) {
-            if (e.name === 'ErrorContext' && e.unprocessable()) {
+            if (e instanceof RequestError && e.status === 422) {
+                // fast-forward failure returns 422 (unprocessable entity)
                 await this._stagedPosition.compute();
                 if (this._stagedPosition.diverged())
                     this._log("could not fast-forward, the base " + this._prBaseBranchPath() + " was probably modified while we were merging");

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1574,6 +1574,7 @@ class PullRequest {
     async _supplyStagingWithPrRequired() {
         assert(this._stagedStatuses.succeeded());
 
+        let createdStatuses = 0;
         for (let requiredContext of this._contextsRequiredByGitHubConfig) {
             if (this._stagedStatuses.hasStatus(requiredContext)) {
                 this._log("_supplyStagingWithPrRequired: skip existing " + requiredContext);
@@ -1595,8 +1596,17 @@ class PullRequest {
 
             await GH.createStatus(this._stagedSha(), check.state, check.targetUrl,
                     check.description, check.context);
+            createdStatuses++;
 
             this._stagedStatuses.addOptionalStatus(check);
+        }
+
+        await Util.sleep(3000); // hard-coded 3 seconds
+        this._stagedStatuses = await this._getStagingStatuses();
+        for (let requiredContext of this._contextsRequiredByGitHubConfig) {
+            if (!this._stagedStatuses.hasStatus(requiredContext)) {
+                throw new Error(`The applied ${requiredContext} PR status does not exist`);
+            }
         }
     }
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1574,7 +1574,6 @@ class PullRequest {
     async _supplyStagingWithPrRequired() {
         assert(this._stagedStatuses.succeeded());
 
-        let createdStatuses = 0;
         for (let requiredContext of this._contextsRequiredByGitHubConfig) {
             if (this._stagedStatuses.hasStatus(requiredContext)) {
                 this._log("_supplyStagingWithPrRequired: skip existing " + requiredContext);
@@ -1596,17 +1595,8 @@ class PullRequest {
 
             await GH.createStatus(this._stagedSha(), check.state, check.targetUrl,
                     check.description, check.context);
-            createdStatuses++;
 
             this._stagedStatuses.addOptionalStatus(check);
-        }
-
-        await Util.sleep(3000); // hard-coded 3 seconds
-        this._stagedStatuses = await this._getStagingStatuses();
-        for (let requiredContext of this._contextsRequiredByGitHubConfig) {
-            if (!this._stagedStatuses.hasStatus(requiredContext)) {
-                throw new Error(`The applied ${requiredContext} PR status does not exist`);
-            }
         }
     }
 

--- a/src/Util.js
+++ b/src/Util.js
@@ -31,44 +31,6 @@ export function ParsePrNumber(prMessage) {
     return prNumber;
 }
 
-// An error context for promisificated wrappers.
-export class ErrorContext extends Error {
-    // The underlying rejection may be a bot-specific Promise.reject() or
-    // be caused by a GitHub API error, so 'err' contains either
-    // an error string or the entire API error object.
-    constructor(err, method, args) {
-        assert(err);
-        let msg = "";
-        if (method !== undefined)
-            msg = method + ", ";
-        msg += "Error: " + JSON.stringify(err);
-        if (args !== undefined)
-            msg += ", params: " + JSON.stringify(args);
-        super(msg);
-        this.name = this.constructor.name;
-        Error.captureStackTrace(this, this.constructor);
-        this._err = err;
-    }
-
-    // 404 (Not found)
-    notFound() {
-        if (this._err.name === "HttpError")
-            return this._err.code === 404;
-        // We treat our local(non-API) promise rejections as
-        // if the requested resource was 'not found'.
-        // TODO: rework if this simple approach does not work.
-        return true;
-    }
-
-    // 422 (unprocessable entity).
-    // E.g., fast-forward failure returns this error.
-    unprocessable() {
-        if (this._err.name === "HttpError")
-            return this._err.code === 422;
-        return false;
-    }
-}
-
 // Identifies or refers to a PR using either
 // PR number, or
 // PR branch name (without 'refs' or 'heads' prefixes), or


### PR DESCRIPTION
After we apply required status checks to a staged commit and
subsequently attempt to merge that commit, GitHub may return an error
that the staged commit lacks those required checks. Evidently, GitHub
responds to a createStatus() call before that call has an effect, and it
may take a few seconds for the checks to be actually applied. Now we
wait up to 2 minutes and report an error if the status is still missing.

Also removed ErrorContext class and fixed the related exception
handlers. ErrorContext was used in old Anubis versions in promisificated
wrappers of Octokit API calls. After updating Octokit to v21 at c1fac18,
ErrorContext was eliminated from all wrappers but one getPR() call.
Now the last use case is gone and hence, the class itself too.

Also fixed broken exception handlers with ErrorContext checks
(unreachable since c1fac18). We should analyze these 404 and 422 errors
using Octokit-generated RequestError instead. The new error handling
differs from the old one: Previously, we treated 404 and 422 errors, as
well as all non-HTTP errors, as 'notFound()' or 'unprocessale()',
depending on the context.  Now we consider only genuine 404 and 422
errors as such.  However, this behavior change should probably not
matter now since the old behavior has been broken since c1fac18.

