### PR TITLE
Validate merge commit freshness before creating the staged commit

### DIFF
--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1219,10 +1219,6 @@ class PullRequest {
         if (!this._prStatuses.final())
             throw this._exObviousFailure("waiting for PR checks");
 
-        const baseSha = await GH.getReference(this._prBaseBranchPath());
-        if (!this._mergeCommit.parents.some(p => p.sha === baseSha))
-            throw this._exLabeledFailure("PR merge commit is stale", Config.failedOtherLabel());
-
         assert(this._prStatuses.succeeded());
     }
 
@@ -1709,6 +1705,9 @@ class PullRequest {
 
     async _createStaged() {
         const baseSha = await GH.getReference(this._prBaseBranchPath());
+        if (!this._mergeCommit.parents.some(p => p.sha === baseSha))
+            throw this._exLabeledFailure("PR merge commit is stale", Config.failedOtherLabel());
+
         if (!Config.githubUserName())
             await this._acquireUserProperties();
         let now = new Date();

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1542,6 +1542,13 @@ class PullRequest {
         if (!treeShaIsFresh)
             return false;
 
+        assert(this._stagedCommit.parents.length === 1);
+        const stagedCommitParentSha = this._stagedCommit.parents[0].sha;
+        const parentIsFresh = this._mergeCommit.parents.some(p => p.sha === stagedCommitParentSha);
+        this._log("staged commit parent freshness: " + parentIsFresh);
+        if (!parentIsFresh)
+            return false;
+
         const stagedCommitDate = new Date(this._stagedCommit.author.date);
         const prCommitDate = new Date(this._commitMessage.author().date);
         // check that a 'no-change' PR commit did not update the merge commit

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1219,6 +1219,10 @@ class PullRequest {
         if (!this._prStatuses.final())
             throw this._exObviousFailure("waiting for PR checks");
 
+        const baseSha = await GH.getReference(this._prBaseBranchPath());
+        if (!this._mergeCommit.parents.some(p => p.sha === baseSha))
+            throw this._exLabeledFailure("PR merge commit is stale", Config.failedOtherLabel());
+
         assert(this._prStatuses.succeeded());
     }
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1716,12 +1716,10 @@ class PullRequest {
 
         const baseSha = await GH.getReference(this._prBaseBranchPath());
         // We want to fast-forward this._mergeCommit code changes into the base branch, but we
-        // cannot use this._mergeCommit.parents as this._stagedCommit parents because we do
-        // not want to preserve the full, branched history of the PR (in other words, we follow
-        // the "Squash and merge" rather than the "Create a merge commit" strategy that user
-        // selects while they manually merge PRs on Github).
+        // cannot use both this._mergeCommit.parents as this._stagedCommit parents because that
+        // would create a git merge commit, importing PR branch. We want flat history instead.
         // Any commit created with baseSha as a parent can be fast-forwarded. To use baseSha, we must
-        // ensure that this._mergeCommit can still be *fast-forwarded* onto baseSha:
+        // ensure that this._mergeCommit can still be fast-forwarded onto baseSha:
         if (!this._mergeCommit.parents.some(p => p.sha === baseSha))
             throw this._exLabeledFailure("PR merge commit is stale", Config.failedOtherLabel());
         // If base branch changes after the above check, our _stagedPosition.ahead() checks

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1704,10 +1704,6 @@ class PullRequest {
     }
 
     async _createStaged() {
-        const baseSha = await GH.getReference(this._prBaseBranchPath());
-        if (!this._mergeCommit.parents.some(p => p.sha === baseSha))
-            throw this._exLabeledFailure("PR merge commit is stale", Config.failedOtherLabel());
-
         if (!Config.githubUserName())
             await this._acquireUserProperties();
         let now = new Date();
@@ -1718,6 +1714,18 @@ class PullRequest {
 
         assert(this._commitMessage.stageable);
 
+        const baseSha = await GH.getReference(this._prBaseBranchPath());
+        // We want to fast-forward this._mergeCommit code changes into the base branch, but we
+        // cannot use this._mergeCommit.parents as this._stagedCommit parents because we do
+        // not want to preserve the full, branched history of the PR (in other words, we follow
+        // the "Squash and merge" rather than the "Create a merge commit" strategy that user
+        // selects while they manually merge PRs on Github).
+        // Any commit created with baseSha as a parent can be fast-forwarded. To use baseSha, we must
+        // ensure that this._mergeCommit can still be *fast-forwarded* onto baseSha:
+        if (!this._mergeCommit.parents.some(p => p.sha === baseSha))
+            throw this._exLabeledFailure("PR merge commit is stale", Config.failedOtherLabel());
+        // If base branch changes after the above check, our _stagedPosition.ahead() checks
+        // or, ultimately, GH.updateReference(...force:false) call will reject this._stagedCommit.
         this._stagedCommit = await GH.createCommit(this._mergeCommit.tree.sha, this._commitMessage.whole(), [baseSha], this._commitMessage.author(), committer);
 
         assert(!this._stagingBanned);


### PR DESCRIPTION
Recently, GitHub stopped updating its PR merge branch (a.k.a. PR merge
commit) in some previously covered `.mergeable` cases. Our tests suggest
that this now happens when the PR is in the "This branch is out-of-date
with the base branch" state, although GitHub repository configuration or
configuration changes may also effect GitHub's decision to update.

When staging a PR, Anubis gets code tree from PR merge commit object
created by GitHub. A stale PR merge commit results in a stale code tree:
The tree is missing newer commits on the base branch. If stale code is
successfully tested, then, when the staged commit is merged into the
base branch, code changes introduced by those "newer commits" are
removed from the base branch as if those commits were reverted!

* OriginalBase: The tip of the base branch during merge commit creation.
* CurrentBase: The tip of the base branch during staged commit creation.

Anubis stages a commit with CurrentBase as a parent. Prior to this
change, Anubis did not check that CurrentBase is still OriginalBase.
This change adds the missing validation. Anubis now refuses to stage if
CurrentBase is no longer OriginalBase, implying a stale merge commit.

TODO: Entice GitHub to update its stale merge commit.