### PR TITLE
Create PR merge commit instead of relying on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ All configuration fields are required.
 *staged_run*| A boolean option to enable staging-only mode where the bot performs all the merging steps up to (but not including) the target branch update. Eligible PRs are merged into and tested on the staging branch but are never merged into their target branches. Staging-only mode prevents any target branch modifications by the bot. TODO: Check that the PR target branch is not the configured staging branch, setting `M-failed-other` if needed. | false
 *guarded_run*| Enables staging-only mode (see `config::staged_run`) for PRs without a `M-cleared-for-merge` label. Has no effect on PRs with that label. While `config::staged_run` blocks target branch modifications, this option allows them for a human-designated subset of PRs. | false
 *staging_branch* | The name of the bot-maintained git branch used for testing PR changes as if they were merged into their target branch. | auto
+*merge_branch* | The name of the bot-maintained git branch used for keeping the result of merging the PR branch into the base branch. | auto__
 *necessary_approvals* | The minimal number of core developers required for a PR to be merged. PRs with fewer votes are not merged, regardless of their age. | 1
 *sufficient_approvals* | The minimal number of core developers required for a PR to be merged fast (i.e., without waiting for `config::voting_delay_max`) | 2
 *core_developers* | The comma-separated list of login=id pairs, specifying GitHub login and ID for core developers. | ""

--- a/README.md
+++ b/README.md
@@ -248,9 +248,7 @@ formatting but strips any trailing whitespace.
 Anubis assembles the staging git commit (and, hence, in case of a successful
 PR merge, the target branch commit) from the following parts:
 
-* `tree`: The git tree object of the PR [merge
-  commit](https://developer.github.com/v3/pulls/#get-a-single-pull-request)
-  created by GitHub.
+* `tree`: The git tree object from the PR merge commit.
 * `parents`: The HEAD commit of the PR base branch.
 * `message`: See the "Commit message" subsection for details.
 * `author`: The name and email from the author object of the PR merge commit
@@ -379,7 +377,7 @@ All configuration fields are required.
 *staged_run*| A boolean option to enable staging-only mode where the bot performs all the merging steps up to (but not including) the target branch update. Eligible PRs are merged into and tested on the staging branch but are never merged into their target branches. Staging-only mode prevents any target branch modifications by the bot. TODO: Check that the PR target branch is not the configured staging branch, setting `M-failed-other` if needed. | false
 *guarded_run*| Enables staging-only mode (see `config::staged_run`) for PRs without a `M-cleared-for-merge` label. Has no effect on PRs with that label. While `config::staged_run` blocks target branch modifications, this option allows them for a human-designated subset of PRs. | false
 *staging_branch* | The name of the bot-maintained git branch used for testing PR changes as if they were merged into their target branch. | auto
-*merge_branch* | The name of the bot-maintained git branch used for keeping the result of merging the PR branch into the target branch. | auto__
+*bot_merge_branch* | The name of the bot-maintained git branch that is very similar to GitHub-maintained PR merge branch. GitHub no longer updates its PR merge branches (i.e. refs/pull/PULL_REQUEST_NUMBER/merge references) in some important use cases, so Anubis uses its own branch (with a configurable name) instead. The last commit on Anubis bot_merge_branch (PR merge commit) is the result of merging PR branch into PR target branch, as a regular git merge command would do. Anubis uses the code tree from that last commit when creating a squashed commit on the staging_branch. The primary difference between the two branches is that staging_branch ends in a squashed (i.e. single-parent) commit rather than a regular two-parent merge commit; after both branches are updated, a git diff staging_branch..bot_merge_branch command produces no output because both branches contain the same code tree. | auto__
 *necessary_approvals* | The minimal number of core developers required for a PR to be merged. PRs with fewer votes are not merged, regardless of their age. | 1
 *sufficient_approvals* | The minimal number of core developers required for a PR to be merged fast (i.e., without waiting for `config::voting_delay_max`) | 2
 *core_developers* | The comma-separated list of login=id pairs, specifying GitHub login and ID for core developers. | ""

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ All configuration fields are required.
 *staged_run*| A boolean option to enable staging-only mode where the bot performs all the merging steps up to (but not including) the target branch update. Eligible PRs are merged into and tested on the staging branch but are never merged into their target branches. Staging-only mode prevents any target branch modifications by the bot. TODO: Check that the PR target branch is not the configured staging branch, setting `M-failed-other` if needed. | false
 *guarded_run*| Enables staging-only mode (see `config::staged_run`) for PRs without a `M-cleared-for-merge` label. Has no effect on PRs with that label. While `config::staged_run` blocks target branch modifications, this option allows them for a human-designated subset of PRs. | false
 *staging_branch* | The name of the bot-maintained git branch used for testing PR changes as if they were merged into their target branch. | auto
-*merge_branch* | The name of the bot-maintained git branch used for keeping the result of merging the PR branch into the base branch. | auto__
+*merge_branch* | The name of the bot-maintained git branch used for keeping the result of merging the PR branch into the target branch. | auto__
 *necessary_approvals* | The minimal number of core developers required for a PR to be merged. PRs with fewer votes are not merged, regardless of their age. | 1
 *sufficient_approvals* | The minimal number of core developers required for a PR to be merged fast (i.e., without waiting for `config::voting_delay_max`) | 2
 *core_developers* | The comma-separated list of login=id pairs, specifying GitHub login and ID for core developers. | ""

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ request state:
   staging results are no longer fresh/applicable.
 * `M-abandoned-staging-checks`: Anubis discovered a stale _staging commit_.
   This usually happens when either the PR state changes (e.g., the author
-  commits new code) or the staging_branch is unexpectedly modified. After
+  commits new code) or the `staging_branch` is unexpectedly modified. After
   labeling the PR, the bot ignores any failed or unfinished tests associated
   with that stale commit. This label was added so that the developer observing
   the PR page on GitHub knows why Anubis ignored (failed, unfinished, or
@@ -248,13 +248,13 @@ formatting but strips any trailing whitespace.
 Anubis assembles the staging git commit (and, hence, in case of a successful
 PR merge, the target branch commit) from the following parts:
 
-* `tree`: The git tree object from the PR merge commit.
+* `tree`: The git tree object from the bot PR merge commit.
 * `parents`: The HEAD commit of the PR base branch.
 * `message`: See the "Commit message" subsection for details.
-* `author`: The name and email from the author object of the PR merge commit
+* `author`: The name and email from the author object of the GitHub PR merge commit
   unless overwritten by the `Authored-by` header field value from the PR
   description header.
-* `author.date`: The date from the author object of the PR merge commit.
+* `author.date`: The date from the author object of the GitHub PR merge commit.
 
 Note that the individual commits on the PR branch (including their messages
 and authors) are ignored. The bot is effectively performing a squash merge
@@ -377,7 +377,7 @@ All configuration fields are required.
 *staged_run*| A boolean option to enable staging-only mode where the bot performs all the merging steps up to (but not including) the target branch update. Eligible PRs are merged into and tested on the staging branch but are never merged into their target branches. Staging-only mode prevents any target branch modifications by the bot. TODO: Check that the PR target branch is not the configured staging branch, setting `M-failed-other` if needed. | false
 *guarded_run*| Enables staging-only mode (see `config::staged_run`) for PRs without a `M-cleared-for-merge` label. Has no effect on PRs with that label. While `config::staged_run` blocks target branch modifications, this option allows them for a human-designated subset of PRs. | false
 *staging_branch* | The name of the bot-maintained git branch used for testing PR changes as if they were merged into their target branch. | auto
-*bot_merge_branch* | The name of the bot-maintained git branch that is very similar to GitHub-maintained PR merge branch. GitHub no longer updates its PR merge branches (i.e. refs/pull/PULL_REQUEST_NUMBER/merge references) in some important use cases, so Anubis uses its own branch (with a configurable name) instead. The last commit on Anubis bot_merge_branch (PR merge commit) is the result of merging PR branch into PR target branch, as a regular git merge command would do. Anubis uses the code tree from that last commit when creating a squashed commit on the staging_branch. The primary difference between the two branches is that staging_branch ends in a squashed (i.e. single-parent) commit rather than a regular two-parent merge commit; after both branches are updated, a git diff staging_branch..bot_merge_branch command produces no output because both branches contain the same code tree. | auto__
+*bot_merge_branch* | The name of the bot-maintained git branch that is very similar to GitHub-maintained PR merge branch. GitHub no longer updates its PR merge branches (i.e. `refs/pull/PULL_REQUEST_NUMBER/merge references`) in some important use cases, so Anubis uses its own branch (with a configurable name) instead. The last commit on Anubis `bot_merge_branch` (the bot PR merge commit) is the result of merging PR branch into PR target branch, as a regular git merge command would do. Anubis uses the code tree from that last commit when creating a squashed commit on the `staging_branch`. The primary difference between the two branches is that `staging_branch` ends in a squashed (i.e. single-parent) commit rather than a regular two-parent merge commit; after both branches are updated, a `git diff staging_branch..bot_merge_branch` command produces no output because both branches contain the same code tree. | auto__
 *necessary_approvals* | The minimal number of core developers required for a PR to be merged. PRs with fewer votes are not merged, regardless of their age. | 1
 *sufficient_approvals* | The minimal number of core developers required for a PR to be merged fast (i.e., without waiting for `config::voting_delay_max`) | 2
 *core_developers* | The comma-separated list of login=id pairs, specifying GitHub login and ID for core developers. | ""

--- a/config-example.json
+++ b/config-example.json
@@ -10,7 +10,7 @@
     "dry_run": false,
     "staged_run": false,
     "staging_branch": "auto",
-    "merge_branch": "auto__",
+    "bot_merge_branch": "auto__",
     "necessary_approvals": 1,
     "sufficient_approvals": 2,
     "voting_delay_min": "2d",

--- a/config-example.json
+++ b/config-example.json
@@ -10,6 +10,7 @@
     "dry_run": false,
     "staged_run": false,
     "staging_branch": "auto",
+    "merge_branch": "auto__",
     "necessary_approvals": 1,
     "sufficient_approvals": 2,
     "voting_delay_min": "2d",

--- a/src/Config.js
+++ b/src/Config.js
@@ -90,6 +90,10 @@ class ConfigOptions {
     baseUrl() { return 'https://api.github.com'; }
     stagingBranchPath() { return "heads/" + this._stagingBranch; }
     stagingBranch() { return this._stagingBranch; }
+    // A special branch that is set to point to a
+    // manually created PR merge commit. TODO: make configurable.
+    mergingBranch() { return "merge_branch"; }
+    mergingBranchPath() { return "heads/" + this.mergingBranch(); }
     dryRun() { return this._dryRun; }
     stagedRun() { return this._stagedRun; }
     guardedRun() { return this._guardedRun; }

--- a/src/Config.js
+++ b/src/Config.js
@@ -21,7 +21,7 @@ class ConfigOptions {
         this._port = conf.port;
         this._owner = conf.owner;
         this._stagingBranch = conf.staging_branch;
-        this._mergeBranch = conf.merge_branch;
+        this._botMergeBranch = conf.bot_merge_branch;
         this._dryRun = conf.dry_run;
         this._stagedRun = conf.staged_run;
         this._guardedRun = conf.guarded_run;
@@ -91,8 +91,8 @@ class ConfigOptions {
     baseUrl() { return 'https://api.github.com'; }
     stagingBranchPath() { return "heads/" + this._stagingBranch; }
     stagingBranch() { return this._stagingBranch; }
-    mergeBranchPath() { return "heads/" + this._mergeBranch; }
-    mergeBranch() { return this._mergeBranch; }
+    botMergeBranchPath() { return "heads/" + this._botMergeBranch; }
+    botMergeBranch() { return this._botMergeBranch; }
     dryRun() { return this._dryRun; }
     stagedRun() { return this._stagedRun; }
     guardedRun() { return this._guardedRun; }

--- a/src/Config.js
+++ b/src/Config.js
@@ -21,6 +21,7 @@ class ConfigOptions {
         this._port = conf.port;
         this._owner = conf.owner;
         this._stagingBranch = conf.staging_branch;
+        this._mergeBranch = conf.merge_branch;
         this._dryRun = conf.dry_run;
         this._stagedRun = conf.staged_run;
         this._guardedRun = conf.guarded_run;
@@ -90,10 +91,8 @@ class ConfigOptions {
     baseUrl() { return 'https://api.github.com'; }
     stagingBranchPath() { return "heads/" + this._stagingBranch; }
     stagingBranch() { return this._stagingBranch; }
-    // A special branch that is set to point to a
-    // manually created PR merge commit. TODO: make configurable.
-    mergingBranch() { return "merge_branch"; }
-    mergingBranchPath() { return "heads/" + this.mergingBranch(); }
+    mergeBranchPath() { return "heads/" + this._mergeBranch; }
+    mergeBranch() { return this._mergeBranch; }
     dryRun() { return this._dryRun; }
     stagedRun() { return this._stagedRun; }
     guardedRun() { return this._guardedRun; }

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -205,7 +205,7 @@ export async function getReference(ref) {
 
 export async function updateReference(ref, sha, force) {
     assert(!Config.dryRun());
-    assert((ref === Config.stagingBranchPath() || ref === Config.mergingBranchPath()) || !Config.stagedRun());
+    assert((ref === Config.stagingBranchPath() || ref === Config.botMergeBranchPath()) || !Config.stagedRun());
 
     let params = commonParams();
     params.ref = ref;
@@ -217,18 +217,16 @@ export async function updateReference(ref, sha, force) {
     return await rateLimitedPromise(result);
 }
 
-export async function mergeBranch(base, head) {
+export async function mergeAintoB(head, base) {
     assert(!Config.dryRun());
     let params = commonParams();
     params.base = base;
     params.head = head;
-    params.commit_message = `Merged ${head} into ${base}`;
+    params.commit_message = `Merged ${head} into ${base} to create a staged commit code tree`;
     const result = await GitHub.rest.repos.merge(params);
-    if (result.status === 204) {
-        throw new Error(`did not merge ${head} into ${base}: already merged`);
-    }
-    assert(result.status === 201);
-    logApiResult(mergeBranch.name, params, {sha: result.data.sha});
+    logApiResult(mergeAintoB.name, params, {sha: result.data.sha});
+    if (result.status !== 201)
+        throw new Error(`did not merge ${head} into ${base}: HTTP status code ${result.status}`);
     return await rateLimitedPromise(result);
 }
 

--- a/src/GitHubUtil.js
+++ b/src/GitHubUtil.js
@@ -205,7 +205,7 @@ export async function getReference(ref) {
 
 export async function updateReference(ref, sha, force) {
     assert(!Config.dryRun());
-    assert((ref === Config.stagingBranchPath()) || !Config.stagedRun());
+    assert((ref === Config.stagingBranchPath() || ref === Config.mergingBranchPath()) || !Config.stagedRun());
 
     let params = commonParams();
     params.ref = ref;
@@ -217,6 +217,20 @@ export async function updateReference(ref, sha, force) {
     return await rateLimitedPromise(result);
 }
 
+export async function mergeBranch(base, head) {
+    assert(!Config.dryRun());
+    let params = commonParams();
+    params.base = base;
+    params.head = head;
+    params.commit_message = `Merged ${head} into ${base}`;
+    const result = await GitHub.rest.repos.merge(params);
+    if (result.status === 204) {
+        throw new Error(`did not merge ${head} into ${base}: already merged`);
+    }
+    assert(result.status === 201);
+    logApiResult(mergeBranch.name, params, {sha: result.data.sha});
+    return await rateLimitedPromise(result);
+}
 
 export async function updatePR(prNum, state) {
     assert(!Config.dryRun());

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1335,8 +1335,8 @@ class PullRequest {
 
     _createdAt() { return this._rawPr.created_at; }
 
-    // Github-generated merge commit path
-    _defaultMergePath() { return "pull/" + this._rawPr.number + "/merge"; }
+    // GitHub-generated PR merge branch. This branch may not reflect the latest target branch changes!
+    _oldGhMergeBranchPath() { return "pull/" + this._rawPr.number + "/merge"; }
 
     _stagedSha() { return this._stagedCommit ? this._stagedCommit.sha : null; }
 
@@ -1499,11 +1499,11 @@ class PullRequest {
         let defaultAuthor = null;
         let stageable = false;
         if (this._prMergeable()) {
-            const defaultMergeSha = await GH.getReference(this._defaultMergePath());
-            const defaultMergeCommit = await GH.getCommit(defaultMergeSha);
-            // Github regenerates its ephemeral merge commit each time the PR branch is updated.
-            // Author attributes will be up to date with the latest PR branch changes.
-            defaultAuthor = defaultMergeCommit.author;
+            const oldGhMergeBranchSha = await GH.getReference(this._oldGhMergeBranchPath());
+            const oldGhMergeBranchCommit = await GH.getCommit(oldGhMergeBranchSha);
+            // GitHub does reset its merge branch each time the PR branch is updated,
+            // keeping author attributes up to date with the latest PR branch changes.
+            defaultAuthor = oldGhMergeBranchCommit.author;
             stageable = true;
         } else {
             const headCommit = await GH.getCommit(this._prHeadSha());
@@ -1539,19 +1539,32 @@ class PullRequest {
         if (!authorIsFresh)
             return false;
 
-        const mergeSha = await GH.getReference(Config.mergeBranchPath());
+        const mergeSha = await GH.getReference(Config.botMergeBranchPath());
         const mergeCommit = await GH.getCommit(mergeSha);
+
+        assert(this._stagedCommit.parents.length === 1);
+        assert(mergeCommit.parents.length === 2);
+
+        const prParentIsFresh = mergeCommit.parents.some(p => p.sha === this._prHeadSha());
+        this._log("merge commit PR branch parent freshness: " + prParentIsFresh);
+        if (!prParentIsFresh)
+            return false;
+
+        const baseSha = await GH.getReference(this._prBaseBranchPath());
+        const baseParentIsFresh = mergeCommit.parents.some(p => p.sha === baseSha);
+        this._log("merge commit base branch parent freshness: " + baseParentIsFresh);
+        if (!baseParentIsFresh)
+            return false;
 
         const treeShaIsFresh = this._stagedCommit.tree.sha === mergeCommit.tree.sha;
         this._log("staged commit tree sha freshness: " + treeShaIsFresh);
         if (!treeShaIsFresh)
             return false;
 
-        assert(this._stagedCommit.parents.length === 1);
         const stagedCommitParentSha = this._stagedCommit.parents[0].sha;
-        const parentIsFresh = mergeCommit.parents.some(p => p.sha === stagedCommitParentSha);
-        this._log("staged commit parent freshness: " + parentIsFresh);
-        if (!parentIsFresh)
+        const stagedCommitParentShaIsFresh = stagedCommitParentSha === baseSha;
+        this._log("staged commit parent sha freshness: " + stagedCommitParentShaIsFresh);
+        if (!stagedCommitParentShaIsFresh)
             return false;
 
         const stagedCommitDate = new Date(this._stagedCommit.author.date);
@@ -1726,13 +1739,18 @@ class PullRequest {
 
         assert(this._commitMessage.stageable);
 
-        // We have to create the merge commit manually because Github stopped generating merge commits
-        // reliably any time the base branch changes.
+        // To create a PR merge commit manually,
+        // we start by resetting our PR merge branch to become the same as PR base branch.
         const baseSha = await GH.getReference(this._prBaseBranchPath());
-        await GH.updateReference(Config.mergeBranchPath(), baseSha, true);
-        const mergeCommit = await GH.mergeBranch(Config.mergeBranch(), this._prHeadBranch());
+        await GH.updateReference(Config.botMergeBranchPath(), baseSha, true);
 
-        // If base branch changes after the above check, our _stagedPosition.ahead() checks
+        // And then merge PR branch changes into our merge branch (as a two-parent merge commit).
+        const mergeCommit = await GH.mergeAintoB(this._prHeadBranch(), Config.botMergeBranch());
+
+        // We want to eventually fast-forward mergeCommit into the base branch, but we
+        // cannot use both mergeCommit.parents as this._stagedCommit parents because that
+        // would create a git merge commit, importing PR branch. We want flat history with one commit per PR instead.
+        // If base branch changes after mergeCommit creation, our _stagedPosition.ahead() checks
         // or, ultimately, GH.updateReference(...force:false) call will reject this._stagedCommit.
         this._stagedCommit = await GH.createCommit(mergeCommit.commit.tree.sha, this._commitMessage.whole(), [baseSha], this._commitMessage.author(), committer);
 

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1128,7 +1128,7 @@ class PullRequest {
             // check this separately because GitHub does not recreate PR merge commits
             // for conflicted PR branches (leaving stale PR merge commits).
             this._prMergeable() &&
-            this._stagedCommitMetadataIsFresh()) {
+            (await this._stagedCommitMetadataIsFresh())) {
 
             this._log("the staged commit is fresh");
             return true;
@@ -1296,6 +1296,8 @@ class PullRequest {
 
     _prHeadSha() { return this._rawPr.head.sha; }
 
+    _prHeadBranch() { return this._rawPr.head.ref; }
+
     _draftPr() {
         // TODO: Remove this backward compatibility code after 2021-12-24.
         if (this._rawPr.title.startsWith('WIP:'))
@@ -1329,13 +1331,12 @@ class PullRequest {
 
     _prBaseBranchPath() { return "heads/" + this._prBaseBranch(); }
 
-    _prHeadBranch() { return this._rawPr.head.ref; }
-
     _prOpen() { return this._rawPr.state === 'open'; }
 
     _createdAt() { return this._rawPr.created_at; }
 
-    _mergePath() { return "pull/" + this._rawPr.number + "/merge"; }
+    // Github-generated merge commit path
+    _defaultMergePath() { return "pull/" + this._rawPr.number + "/merge"; }
 
     _stagedSha() { return this._stagedCommit ? this._stagedCommit.sha : null; }
 
@@ -1495,8 +1496,17 @@ class PullRequest {
 
         this._rawPr = pr;
 
-        const headCommit = await GH.getCommit(this._prHeadSha());
-        let defaultAuthor = headCommit.author;
+        let defaultAuthor = null;
+        let stageable = false;
+        if (this._prMergeable()) {
+            const defaultMergeSha = await GH.getReference(this._defaultMergePath());
+            const defaultMergeCommit = await GH.getCommit(defaultMergeSha);
+            defaultAuthor = defaultMergeCommit.author;
+            stageable = true;
+        } else {
+            const headCommit = await GH.getCommit(this._prHeadSha());
+            defaultAuthor = headCommit.author;
+        }
 
         try {
             this._commitMessage = new CommitMessage(this._rawPr, defaultAuthor, this._prMergeable());
@@ -1510,7 +1520,7 @@ class PullRequest {
     }
 
     // Whether the staged commit metadata remained intact since staging.
-    _stagedCommitMetadataIsFresh() {
+    async _stagedCommitMetadataIsFresh() {
         if (!this._commitMessage) {
             this._log("staged commit message became invalid (and will be treated as stale)");
             return false;
@@ -1525,6 +1535,21 @@ class PullRequest {
         const authorIsFresh = oldAuthor.name === newAuthor.name && oldAuthor.email === newAuthor.email;
         this._log("staged commit author freshness: " + authorIsFresh);
         if (!authorIsFresh)
+            return false;
+
+        const mergeSha = await GH.getReference(Config.mergingBranchPath());
+        const mergeCommit = await GH.getCommit(mergeSha);
+
+        const treeShaIsFresh = this._stagedCommit.tree.sha === mergeCommit.tree.sha;
+        this._log("staged commit tree sha freshness: " + treeShaIsFresh);
+        if (!treeShaIsFresh)
+            return false;
+
+        assert(this._stagedCommit.parents.length === 1);
+        const stagedCommitParentSha = this._stagedCommit.parents[0].sha;
+        const parentIsFresh = mergeCommit.parents.some(p => p.sha === stagedCommitParentSha);
+        this._log("staged commit parent freshness: " + parentIsFresh);
+        if (!parentIsFresh)
             return false;
 
         const stagedCommitDate = new Date(this._stagedCommit.author.date);
@@ -1708,11 +1733,9 @@ class PullRequest {
         // If base branch changes after the above check, our _stagedPosition.ahead() checks
         // or, ultimately, GH.updateReference(...force:false) call will reject this._stagedCommit.
         this._stagedCommit = await GH.createCommit(mergeCommit.commit.tree.sha, this._commitMessage.whole(), [baseSha], this._commitMessage.author(), committer);
+
         assert(!this._stagingBanned);
         await GH.updateReference(Config.stagingBranchPath(), this._stagedSha(), true);
-        // Github does not automatically link our staged commit with the PR, do this manually.
-        const stagedCommitComment = `Created staged commit ${this._stagedCommit.sha}.`;
-        await GH.createComment(this._prNumber(), stagedCommitComment);
 
         this._stagedPosition = new BranchPosition(this._prBaseBranch(), Config.stagingBranch());
         // If needed, give GitHub extra time to update the staging branch,

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -873,9 +873,6 @@ class PullRequest {
 
         this._stagedPosition = null;
 
-        // this PR merge commit received from GitHub, if any
-        this._mergeCommit = null;
-
         // this PR staged commit received from GitHub, if any
         this._stagedCommit = null;
 
@@ -1332,6 +1329,8 @@ class PullRequest {
 
     _prBaseBranchPath() { return "heads/" + this._prBaseBranch(); }
 
+    _prHeadBranch() { return this._rawPr.head.ref; }
+
     _prOpen() { return this._rawPr.state === 'open'; }
 
     _createdAt() { return this._rawPr.created_at; }
@@ -1496,20 +1495,11 @@ class PullRequest {
 
         this._rawPr = pr;
 
-        let defaultAuthor = null;
-        let stageable = false;
-        if (this._prMergeable()) {
-            const mergeSha = await GH.getReference(this._mergePath());
-            this._mergeCommit = await GH.getCommit(mergeSha);
-            defaultAuthor = this._mergeCommit.author;
-            stageable = true;
-        } else {
-            const headCommit = await GH.getCommit(this._prHeadSha());
-            defaultAuthor = headCommit.author;
-        }
+        const headCommit = await GH.getCommit(this._prHeadSha());
+        let defaultAuthor = headCommit.author;
 
         try {
-            this._commitMessage = new CommitMessage(this._rawPr, defaultAuthor, stageable);
+            this._commitMessage = new CommitMessage(this._rawPr, defaultAuthor, this._prMergeable());
         } catch (e) {
             if (!(e instanceof PrDescriptionProblem))
                 throw e;
@@ -1535,18 +1525,6 @@ class PullRequest {
         const authorIsFresh = oldAuthor.name === newAuthor.name && oldAuthor.email === newAuthor.email;
         this._log("staged commit author freshness: " + authorIsFresh);
         if (!authorIsFresh)
-            return false;
-
-        const treeShaIsFresh = this._stagedCommit.tree.sha === this._mergeCommit.tree.sha;
-        this._log("staged commit tree sha freshness: " + treeShaIsFresh);
-        if (!treeShaIsFresh)
-            return false;
-
-        assert(this._stagedCommit.parents.length === 1);
-        const stagedCommitParentSha = this._stagedCommit.parents[0].sha;
-        const parentIsFresh = this._mergeCommit.parents.some(p => p.sha === stagedCommitParentSha);
-        this._log("staged commit parent freshness: " + parentIsFresh);
-        if (!parentIsFresh)
             return false;
 
         const stagedCommitDate = new Date(this._stagedCommit.author.date);
@@ -1721,20 +1699,20 @@ class PullRequest {
 
         assert(this._commitMessage.stageable);
 
+        // We have to create the merge commit manually because Github stopped generating merge commits
+        // reliably any time the base branch changes.
         const baseSha = await GH.getReference(this._prBaseBranchPath());
-        // We want to fast-forward this._mergeCommit code changes into the base branch, but we
-        // cannot use both this._mergeCommit.parents as this._stagedCommit parents because that
-        // would create a git merge commit, importing PR branch. We want flat history instead.
-        // Any commit created with baseSha as a parent can be fast-forwarded. To use baseSha, we must
-        // ensure that this._mergeCommit can still be fast-forwarded onto baseSha:
-        if (!this._mergeCommit.parents.some(p => p.sha === baseSha))
-            throw this._exLabeledFailure("PR merge commit is stale", Config.failedOtherLabel());
+        await GH.updateReference(Config.mergingBranchPath(), baseSha, true);
+        const mergeCommit = await GH.mergeBranch(Config.mergingBranch(), this._prHeadBranch());
+
         // If base branch changes after the above check, our _stagedPosition.ahead() checks
         // or, ultimately, GH.updateReference(...force:false) call will reject this._stagedCommit.
-        this._stagedCommit = await GH.createCommit(this._mergeCommit.tree.sha, this._commitMessage.whole(), [baseSha], this._commitMessage.author(), committer);
-
+        this._stagedCommit = await GH.createCommit(mergeCommit.commit.tree.sha, this._commitMessage.whole(), [baseSha], this._commitMessage.author(), committer);
         assert(!this._stagingBanned);
         await GH.updateReference(Config.stagingBranchPath(), this._stagedSha(), true);
+        // Github does not automatically link our staged commit with the PR, do this manually.
+        const stagedCommitComment = `Created staged commit ${this._stagedCommit.sha}.`;
+        await GH.createComment(this._prNumber(), stagedCommitComment);
 
         this._stagedPosition = new BranchPosition(this._prBaseBranch(), Config.stagingBranch());
         // If needed, give GitHub extra time to update the staging branch,

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1501,6 +1501,8 @@ class PullRequest {
         if (this._prMergeable()) {
             const defaultMergeSha = await GH.getReference(this._defaultMergePath());
             const defaultMergeCommit = await GH.getCommit(defaultMergeSha);
+            // Github regenerates its ephemeral merge commit each time the PR branch is updated.
+            // Author attributes will be up to date with the latest PR branch changes.
             defaultAuthor = defaultMergeCommit.author;
             stageable = true;
         } else {
@@ -1509,7 +1511,7 @@ class PullRequest {
         }
 
         try {
-            this._commitMessage = new CommitMessage(this._rawPr, defaultAuthor, this._prMergeable());
+            this._commitMessage = new CommitMessage(this._rawPr, defaultAuthor, stageable);
         } catch (e) {
             if (!(e instanceof PrDescriptionProblem))
                 throw e;
@@ -1537,7 +1539,7 @@ class PullRequest {
         if (!authorIsFresh)
             return false;
 
-        const mergeSha = await GH.getReference(Config.mergingBranchPath());
+        const mergeSha = await GH.getReference(Config.mergeBranchPath());
         const mergeCommit = await GH.getCommit(mergeSha);
 
         const treeShaIsFresh = this._stagedCommit.tree.sha === mergeCommit.tree.sha;
@@ -1727,8 +1729,8 @@ class PullRequest {
         // We have to create the merge commit manually because Github stopped generating merge commits
         // reliably any time the base branch changes.
         const baseSha = await GH.getReference(this._prBaseBranchPath());
-        await GH.updateReference(Config.mergingBranchPath(), baseSha, true);
-        const mergeCommit = await GH.mergeBranch(Config.mergingBranch(), this._prHeadBranch());
+        await GH.updateReference(Config.mergeBranchPath(), baseSha, true);
+        const mergeCommit = await GH.mergeBranch(Config.mergeBranch(), this._prHeadBranch());
 
         // If base branch changes after the above check, our _stagedPosition.ahead() checks
         // or, ultimately, GH.updateReference(...force:false) call will reject this._stagedCommit.


### PR DESCRIPTION
We used to rely on GitHub's ability to generate PR merge commits any
time PR's head or base branch changes.  Currently GitHub does not keep
merge commits in sync with the base branch (see recent commit c2ded1e).
There are several ways to force GitHub to re-generate a merge commit:

* switch PR branch to point to a random branch and then switch it back;
* merge PR base branch into PR branch;
* open and close the PR.

We rejected all these options because they are unreliable (e.g., failing
to switch PR base branch back leaves the PR in a bad state) and/or
create noise on PR page, strange notifications and overall bad UX.

Instead of relying on GitHub doing that, Anubis now creates a PR merge
commit, using a dedicated branch with a configurable name
(`bot_merge_branch`).
