### PR TITLE
Use SHA of a local PR head branch instead of remote branch name when merging

### DIFF
--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1745,7 +1745,7 @@ class PullRequest {
         await GH.updateReference(Config.botMergeBranchPath(), baseSha, true);
 
         // And then merge PR branch changes into our merge branch (as a two-parent merge commit).
-        const mergeCommit = await GH.mergeAintoB(this._prHeadBranch(), Config.botMergeBranch());
+        const mergeCommit = await GH.mergeAintoB(this._prHeadSha(), Config.botMergeBranch());
 
         // We want to eventually fast-forward mergeCommit into the base branch, but we
         // cannot use both mergeCommit.parents as this._stagedCommit parents because that

--- a/src/MergeContext.js
+++ b/src/MergeContext.js
@@ -1296,8 +1296,6 @@ class PullRequest {
 
     _prHeadSha() { return this._rawPr.head.sha; }
 
-    _prHeadBranch() { return this._rawPr.head.ref; }
-
     _draftPr() {
         // TODO: Remove this backward compatibility code after 2021-12-24.
         if (this._rawPr.title.startsWith('WIP:'))


### PR DESCRIPTION
GitHub rest.repos.merge() API cannot merge across repositories: It
returns a 404 error because it cannot locate PR branch named
"someUser:someFeature" that points to another repository. Instead of
using a "remote" PR branch name, we now use the "local" "head branch"
SHA: GitHub creates an internal `refs/pull/{PULL_NUMBER}/head` branch
(similar to how it creates an internal merge branch known as
`refs/pull/{PULL_NUMBER}/merge`). That head branch points to the SHA
commit object located within our/PR-hosting "local" repository.